### PR TITLE
test: add for variations for e2e test

### DIFF
--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -14,6 +14,33 @@ const (
 	featureIDVariation1 = "value-1"
 	featureIDVariation2 = "value-2"
 	goalID              = "goal-go-server-e2e-1"
+
+	// Sdk Test
+	targetUserID                   = "bucketeer-go-server-user-id-1"
+	featureIDString                = "feature-go-server-e2e-1"
+	featureIDStringTargetVariation = featureIDStringVariation2
+	featureIDStringVariation1      = "value-1"
+	featureIDStringVariation2      = "value-2"
+
+	featureIDBoolean                = "feature-go-server-e2e-boolean"
+	featureIDBooleanTargetVariation = false
+
+	featureIDInt                = "feature-go-server-e2e-int"
+	featureIDIntTargetVariation = featureIDIntVariation2
+	featureIDIntVariation1      = 10
+	featureIDIntVariation2      = 20
+
+	featureIDInt64                = "feature-go-server-e2e-int64"
+	featureIDInt64TargetVariation = featureIDInt64Variation2
+	featureIDInt64Variation1      = 3000000000
+	featureIDInt64Variation2      = -3000000000
+
+	featureIDFloat                = "feature-go-server-e2e-float"
+	featureIDFloatTargetVariation = featureIDFloatVariation2
+	featureIDFloatVariation1      = 2.1
+	featureIDFloatVariation2      = 3.1
+
+	featureIDJson = "feature-go-server-e2e-json"
 )
 
 var (

--- a/test/e2e/sdk_test.go
+++ b/test/e2e/sdk_test.go
@@ -12,8 +12,7 @@ import (
 	"github.com/ca-dp/bucketeer-go-server-sdk/pkg/bucketeer/user"
 )
 
-func TestSDK(t *testing.T) {
-	t.Parallel()
+func TestStringVariation(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	sdk := newSDK(t, ctx)
@@ -25,21 +24,21 @@ func TestSDK(t *testing.T) {
 	var wg sync.WaitGroup
 	testVariationFunc := func(ctx context.Context, userID, featureID, expectedVariation string) {
 		defer wg.Done()
-		user := newUser(t, userID)
-		v := sdk.StringVariation(ctx, user, featureID, "default")
-		assert.Equal(t, expectedVariation, v)
+		u := newUser(t, userID)
+		v := sdk.StringVariation(ctx, u, featureID, "default")
+		assert.Equal(t, expectedVariation, v, "userID: %s, featureID: %s", userID, featureID)
 	}
 
-	// Get Variation by Default Strategy (featureIDVariation1)
+	// Get Variation by Default Strategy
 	for i := 0; i < 3; i++ {
 		wg.Add(1)
 		userID := fmt.Sprintf("user-%d", i)
-		go testVariationFunc(ctx, userID, featureID, featureIDVariation1)
+		go testVariationFunc(ctx, userID, featureIDString, featureIDStringVariation1)
 	}
 
-	// Get Variation by Targeting Users (featureIDVariation2)
+	// Get Variation by Targeting Users
 	wg.Add(1)
-	go testVariationFunc(ctx, userID, featureID, featureIDVariation2)
+	go testVariationFunc(ctx, targetUserID, featureIDString, featureIDStringTargetVariation)
 
 	// Track
 	wg.Add(1)
@@ -48,6 +47,166 @@ func TestSDK(t *testing.T) {
 		user := newUser(t, userID)
 		sdk.Track(ctx, user, goalID)
 	}(ctx, userID, goalID)
+
+	wg.Wait()
+}
+
+func TestBoolVariation(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	sdk := newSDK(t, ctx)
+	defer func() {
+		// Close
+		err := sdk.Close(ctx)
+		assert.NoError(t, err)
+	}()
+	var wg sync.WaitGroup
+	testVariationFunc := func(ctx context.Context, userID, featureID string, expectedVariation bool) {
+		defer wg.Done()
+		u := newUser(t, userID)
+		v := sdk.BoolVariation(ctx, u, featureID, false)
+		assert.Equal(t, expectedVariation, v, "userID: %s, featureID: %s", userID, featureID)
+	}
+
+	// Get Variation by Default Strategy
+	for i := 0; i < 3; i++ {
+		wg.Add(1)
+		userID := fmt.Sprintf("user-%d", i)
+		go testVariationFunc(ctx, userID, featureIDBoolean, true)
+	}
+
+	// Get Variation by Targeting Users
+	wg.Add(1)
+	go testVariationFunc(ctx, targetUserID, featureIDBoolean, featureIDBooleanTargetVariation)
+
+	wg.Wait()
+}
+
+func TestIntVariation(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	sdk := newSDK(t, ctx)
+	defer func() {
+		// Close
+		err := sdk.Close(ctx)
+		assert.NoError(t, err)
+	}()
+	var wg sync.WaitGroup
+	testVariationFunc := func(ctx context.Context, userID, featureID string, expectedVariation int) {
+		defer wg.Done()
+		user := newUser(t, userID)
+		v := sdk.IntVariation(ctx, user, featureID, -1)
+		assert.Equal(t, expectedVariation, v, "userID: %s, featureID: %s", userID, featureID)
+	}
+
+	// Get Variation by Default Strategy
+	for i := 0; i < 3; i++ {
+		wg.Add(1)
+		userID := fmt.Sprintf("user-%d", i)
+		go testVariationFunc(ctx, userID, featureIDInt, featureIDIntVariation1)
+	}
+
+	// Get Variation by Targeting Users
+	wg.Add(1)
+	go testVariationFunc(ctx, targetUserID, featureIDInt, featureIDIntTargetVariation)
+
+	wg.Wait()
+}
+
+func TestInt64Variation(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	sdk := newSDK(t, ctx)
+	defer func() {
+		// Close
+		err := sdk.Close(ctx)
+		assert.NoError(t, err)
+	}()
+	var wg sync.WaitGroup
+	testVariationFunc := func(ctx context.Context, userID, featureID string, expectedVariation int64) {
+		defer wg.Done()
+		user := newUser(t, userID)
+		v := sdk.Int64Variation(ctx, user, featureID, -1000000000)
+		assert.Equal(t, expectedVariation, v, "userID: %s, featureID: %s", userID, featureID)
+	}
+
+	// Get Variation by Default Strategy
+	for i := 0; i < 3; i++ {
+		wg.Add(1)
+		userID := fmt.Sprintf("user-%d", i)
+		go testVariationFunc(ctx, userID, featureIDInt64, featureIDInt64Variation1)
+	}
+
+	// Get Variation by Targeting Users
+	wg.Add(1)
+	go testVariationFunc(ctx, targetUserID, featureIDInt64, featureIDInt64TargetVariation)
+
+	wg.Wait()
+}
+
+func TestFloat64Variation(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	sdk := newSDK(t, ctx)
+	defer func() {
+		// Close
+		err := sdk.Close(ctx)
+		assert.NoError(t, err)
+	}()
+	var wg sync.WaitGroup
+	testVariationFunc := func(ctx context.Context, userID, featureID string, expectedVariation float64) {
+		defer wg.Done()
+		u := newUser(t, userID)
+		v := sdk.Float64Variation(ctx, u, featureID, -1.1)
+		assert.Equal(t, expectedVariation, v, "userID: %s, featureID: %s", userID, featureID)
+	}
+
+	// Get Variation by Default Strategy
+	for i := 0; i < 3; i++ {
+		wg.Add(1)
+		userID := fmt.Sprintf("user-%d", i)
+		go testVariationFunc(ctx, userID, featureIDFloat, featureIDFloatVariation1)
+	}
+
+	// Get Variation by Targeting Users
+	wg.Add(1)
+	go testVariationFunc(ctx, targetUserID, featureIDFloat, featureIDFloatTargetVariation)
+
+	wg.Wait()
+}
+
+func TestJSONVariation(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	sdk := newSDK(t, ctx)
+	defer func() {
+		// Close
+		err := sdk.Close(ctx)
+		assert.NoError(t, err)
+	}()
+	var wg sync.WaitGroup
+	type DstStruct struct {
+		Str string `json:"str"`
+		Int string `json:"int"`
+	}
+	testVariationFunc := func(ctx context.Context, userID, featureID string, expectedVariation interface{}) {
+		defer wg.Done()
+		u := newUser(t, userID)
+		v := &DstStruct{}
+		sdk.JSONVariation(ctx, u, featureID, v)
+		assert.Equal(t, expectedVariation, v, "userID: %s, featureID: %s", userID, featureID)
+	}
+
+	// Get Variation by Default Strategy
+	for i := 0; i < 3; i++ {
+		wg.Add(1)
+		userID := fmt.Sprintf("user-%d", i)
+		go testVariationFunc(ctx, userID, featureIDJson, &DstStruct{Str: "str1", Int: "int1"})
+	}
+
+	// Get Variation by Targeting Users
+	wg.Add(1)
+	go testVariationFunc(ctx, targetUserID, featureIDJson, &DstStruct{Str: "str2", Int: "int2"})
 
 	wg.Wait()
 }

--- a/test/e2e/sdk_test.go
+++ b/test/e2e/sdk_test.go
@@ -2,8 +2,6 @@ package e2e
 
 import (
 	"context"
-	"fmt"
-	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -14,207 +12,248 @@ import (
 
 func TestStringVariation(t *testing.T) {
 	t.Parallel()
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-	sdk := newSDK(t, ctx)
-	defer func() {
-		// Close
-		err := sdk.Close(ctx)
-		assert.NoError(t, err)
-	}()
-	var wg sync.WaitGroup
-	testVariationFunc := func(ctx context.Context, userID, featureID, expectedVariation string) {
-		defer wg.Done()
-		u := newUser(t, userID)
-		v := sdk.StringVariation(ctx, u, featureID, "default")
-		assert.Equal(t, expectedVariation, v, "userID: %s, featureID: %s", userID, featureID)
+
+	tests := []struct {
+		desc      string
+		user      *user.User
+		featureID string
+		expected  string
+	}{
+		{
+			desc:      "get Variation by Default Strategy",
+			user:      newUser(t, "user-1"),
+			featureID: featureIDString,
+			expected:  featureIDStringVariation1,
+		},
+		{
+			desc:      "get Variation by Targeting Strategy",
+			user:      newUser(t, targetUserID),
+			featureID: featureIDString,
+			expected:  featureIDStringTargetVariation,
+		},
 	}
 
-	// Get Variation by Default Strategy
-	for i := 0; i < 3; i++ {
-		wg.Add(1)
-		userID := fmt.Sprintf("user-%d", i)
-		go testVariationFunc(ctx, userID, featureIDString, featureIDStringVariation1)
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), timeout)
+			defer cancel()
+			sdk := newSDK(t, ctx)
+			defer func() {
+				// Close
+				err := sdk.Close(ctx)
+				assert.NoError(t, err)
+			}()
+
+			actual := sdk.StringVariation(ctx, tt.user, tt.featureID, "default")
+			assert.Equal(t, tt.expected, actual, "userID: %s, featureID: %s", tt.user.ID, tt.featureID)
+		})
 	}
-
-	// Get Variation by Targeting Users
-	wg.Add(1)
-	go testVariationFunc(ctx, targetUserID, featureIDString, featureIDStringTargetVariation)
-
-	// Track
-	wg.Add(1)
-	go func(ctx context.Context, userID, goalID string) {
-		defer wg.Done()
-		user := newUser(t, userID)
-		sdk.Track(ctx, user, goalID)
-	}(ctx, userID, goalID)
-
-	wg.Wait()
 }
 
 func TestBoolVariation(t *testing.T) {
 	t.Parallel()
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-	sdk := newSDK(t, ctx)
-	defer func() {
-		// Close
-		err := sdk.Close(ctx)
-		assert.NoError(t, err)
-	}()
-	var wg sync.WaitGroup
-	testVariationFunc := func(ctx context.Context, userID, featureID string, expectedVariation bool) {
-		defer wg.Done()
-		u := newUser(t, userID)
-		v := sdk.BoolVariation(ctx, u, featureID, false)
-		assert.Equal(t, expectedVariation, v, "userID: %s, featureID: %s", userID, featureID)
+
+	tests := []struct {
+		desc      string
+		user      *user.User
+		featureID string
+		expected  bool
+	}{
+		{
+			desc:      "get Variation by Default Strategy",
+			user:      newUser(t, "user-1"),
+			featureID: featureIDBoolean,
+			expected:  true,
+		},
+		{
+			desc:      "get Variation by Targeting Strategy",
+			user:      newUser(t, targetUserID),
+			featureID: featureIDBoolean,
+			expected:  featureIDBooleanTargetVariation,
+		},
 	}
 
-	// Get Variation by Default Strategy
-	for i := 0; i < 3; i++ {
-		wg.Add(1)
-		userID := fmt.Sprintf("user-%d", i)
-		go testVariationFunc(ctx, userID, featureIDBoolean, true)
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), timeout)
+			defer cancel()
+			sdk := newSDK(t, ctx)
+			defer func() {
+				// Close
+				err := sdk.Close(ctx)
+				assert.NoError(t, err)
+			}()
+
+			actual := sdk.BoolVariation(ctx, tt.user, tt.featureID, false)
+			assert.Equal(t, tt.expected, actual, "userID: %s, featureID: %s", tt.user.ID, tt.featureID)
+		})
 	}
-
-	// Get Variation by Targeting Users
-	wg.Add(1)
-	go testVariationFunc(ctx, targetUserID, featureIDBoolean, featureIDBooleanTargetVariation)
-
-	wg.Wait()
 }
 
 func TestIntVariation(t *testing.T) {
 	t.Parallel()
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-	sdk := newSDK(t, ctx)
-	defer func() {
-		// Close
-		err := sdk.Close(ctx)
-		assert.NoError(t, err)
-	}()
-	var wg sync.WaitGroup
-	testVariationFunc := func(ctx context.Context, userID, featureID string, expectedVariation int) {
-		defer wg.Done()
-		user := newUser(t, userID)
-		v := sdk.IntVariation(ctx, user, featureID, -1)
-		assert.Equal(t, expectedVariation, v, "userID: %s, featureID: %s", userID, featureID)
+
+	tests := []struct {
+		desc      string
+		user      *user.User
+		featureID string
+		expected  int
+	}{
+		{
+			desc:      "get Variation by Default Strategy",
+			user:      newUser(t, "user-1"),
+			featureID: featureIDInt,
+			expected:  featureIDIntVariation1,
+		},
+		{
+			desc:      "get Variation by Targeting Strategy",
+			user:      newUser(t, targetUserID),
+			featureID: featureIDInt,
+			expected:  featureIDIntTargetVariation,
+		},
 	}
 
-	// Get Variation by Default Strategy
-	for i := 0; i < 3; i++ {
-		wg.Add(1)
-		userID := fmt.Sprintf("user-%d", i)
-		go testVariationFunc(ctx, userID, featureIDInt, featureIDIntVariation1)
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), timeout)
+			defer cancel()
+			sdk := newSDK(t, ctx)
+			defer func() {
+				// Close
+				err := sdk.Close(ctx)
+				assert.NoError(t, err)
+			}()
+
+			actual := sdk.IntVariation(ctx, tt.user, tt.featureID, -1)
+			assert.Equal(t, tt.expected, actual, "userID: %s, featureID: %s", tt.user.ID, tt.featureID)
+		})
 	}
-
-	// Get Variation by Targeting Users
-	wg.Add(1)
-	go testVariationFunc(ctx, targetUserID, featureIDInt, featureIDIntTargetVariation)
-
-	wg.Wait()
 }
 
 func TestInt64Variation(t *testing.T) {
 	t.Parallel()
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-	sdk := newSDK(t, ctx)
-	defer func() {
-		// Close
-		err := sdk.Close(ctx)
-		assert.NoError(t, err)
-	}()
-	var wg sync.WaitGroup
-	testVariationFunc := func(ctx context.Context, userID, featureID string, expectedVariation int64) {
-		defer wg.Done()
-		user := newUser(t, userID)
-		v := sdk.Int64Variation(ctx, user, featureID, -1000000000)
-		assert.Equal(t, expectedVariation, v, "userID: %s, featureID: %s", userID, featureID)
+
+	tests := []struct {
+		desc      string
+		user      *user.User
+		featureID string
+		expected  int64
+	}{
+		{
+			desc:      "get Variation by Default Strategy",
+			user:      newUser(t, "user-1"),
+			featureID: featureIDInt64,
+			expected:  featureIDInt64Variation1,
+		},
+		{
+			desc:      "get Variation by Targeting Strategy",
+			user:      newUser(t, targetUserID),
+			featureID: featureIDInt64,
+			expected:  featureIDInt64TargetVariation,
+		},
 	}
 
-	// Get Variation by Default Strategy
-	for i := 0; i < 3; i++ {
-		wg.Add(1)
-		userID := fmt.Sprintf("user-%d", i)
-		go testVariationFunc(ctx, userID, featureIDInt64, featureIDInt64Variation1)
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), timeout)
+			defer cancel()
+			sdk := newSDK(t, ctx)
+			defer func() {
+				// Close
+				err := sdk.Close(ctx)
+				assert.NoError(t, err)
+			}()
+
+			actual := sdk.Int64Variation(ctx, tt.user, tt.featureID, -1000000000)
+			assert.Equal(t, tt.expected, actual, "userID: %s, featureID: %s", tt.user.ID, tt.featureID)
+		})
 	}
-
-	// Get Variation by Targeting Users
-	wg.Add(1)
-	go testVariationFunc(ctx, targetUserID, featureIDInt64, featureIDInt64TargetVariation)
-
-	wg.Wait()
 }
 
 func TestFloat64Variation(t *testing.T) {
 	t.Parallel()
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-	sdk := newSDK(t, ctx)
-	defer func() {
-		// Close
-		err := sdk.Close(ctx)
-		assert.NoError(t, err)
-	}()
-	var wg sync.WaitGroup
-	testVariationFunc := func(ctx context.Context, userID, featureID string, expectedVariation float64) {
-		defer wg.Done()
-		u := newUser(t, userID)
-		v := sdk.Float64Variation(ctx, u, featureID, -1.1)
-		assert.Equal(t, expectedVariation, v, "userID: %s, featureID: %s", userID, featureID)
+
+	tests := []struct {
+		desc      string
+		user      *user.User
+		featureID string
+		expected  float64
+	}{
+		{
+			desc:      "get Variation by Default Strategy",
+			user:      newUser(t, "user-1"),
+			featureID: featureIDFloat,
+			expected:  featureIDFloatVariation1,
+		},
+		{
+			desc:      "get Variation by Targeting Strategy",
+			user:      newUser(t, targetUserID),
+			featureID: featureIDFloat,
+			expected:  featureIDFloatTargetVariation,
+		},
 	}
 
-	// Get Variation by Default Strategy
-	for i := 0; i < 3; i++ {
-		wg.Add(1)
-		userID := fmt.Sprintf("user-%d", i)
-		go testVariationFunc(ctx, userID, featureIDFloat, featureIDFloatVariation1)
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), timeout)
+			defer cancel()
+			sdk := newSDK(t, ctx)
+			defer func() {
+				// Close
+				err := sdk.Close(ctx)
+				assert.NoError(t, err)
+			}()
+
+			actual := sdk.Float64Variation(ctx, tt.user, tt.featureID, -1.1)
+			assert.Equal(t, tt.expected, actual, "userID: %s, featureID: %s", tt.user.ID, tt.featureID)
+		})
 	}
-
-	// Get Variation by Targeting Users
-	wg.Add(1)
-	go testVariationFunc(ctx, targetUserID, featureIDFloat, featureIDFloatTargetVariation)
-
-	wg.Wait()
 }
 
 func TestJSONVariation(t *testing.T) {
 	t.Parallel()
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-	sdk := newSDK(t, ctx)
-	defer func() {
-		// Close
-		err := sdk.Close(ctx)
-		assert.NoError(t, err)
-	}()
-	var wg sync.WaitGroup
-	type DstStruct struct {
+
+	type TestJson struct {
 		Str string `json:"str"`
 		Int string `json:"int"`
 	}
-	testVariationFunc := func(ctx context.Context, userID, featureID string, expectedVariation interface{}) {
-		defer wg.Done()
-		u := newUser(t, userID)
-		v := &DstStruct{}
-		sdk.JSONVariation(ctx, u, featureID, v)
-		assert.Equal(t, expectedVariation, v, "userID: %s, featureID: %s", userID, featureID)
+
+	tests := []struct {
+		desc      string
+		user      *user.User
+		featureID string
+		expected  *TestJson
+	}{
+		{
+			desc:      "get Variation by Default Strategy",
+			user:      newUser(t, "user-1"),
+			featureID: featureIDJson,
+			expected:  &TestJson{Str: "str1", Int: "int1"},
+		},
+		{
+			desc:      "get Variation by Targeting Strategy",
+			user:      newUser(t, targetUserID),
+			featureID: featureIDJson,
+			expected:  &TestJson{Str: "str2", Int: "int2"},
+		},
 	}
 
-	// Get Variation by Default Strategy
-	for i := 0; i < 3; i++ {
-		wg.Add(1)
-		userID := fmt.Sprintf("user-%d", i)
-		go testVariationFunc(ctx, userID, featureIDJson, &DstStruct{Str: "str1", Int: "int1"})
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), timeout)
+			defer cancel()
+			sdk := newSDK(t, ctx)
+			defer func() {
+				// Close
+				err := sdk.Close(ctx)
+				assert.NoError(t, err)
+			}()
+
+			v := &TestJson{}
+			sdk.JSONVariation(ctx, tt.user, tt.featureID, v)
+			assert.Equal(t, tt.expected, v, "userID: %s, featureID: %s", tt.user.ID, tt.featureID)
+		})
 	}
-
-	// Get Variation by Targeting Users
-	wg.Add(1)
-	go testVariationFunc(ctx, targetUserID, featureIDJson, &DstStruct{Str: "str2", Int: "int2"})
-
-	wg.Wait()
 }
 
 func newSDK(t *testing.T, ctx context.Context) bucketeer.SDK {

--- a/test/e2e/sdk_test.go
+++ b/test/e2e/sdk_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestStringVariation(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	sdk := newSDK(t, ctx)
@@ -52,6 +53,7 @@ func TestStringVariation(t *testing.T) {
 }
 
 func TestBoolVariation(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	sdk := newSDK(t, ctx)
@@ -83,6 +85,7 @@ func TestBoolVariation(t *testing.T) {
 }
 
 func TestIntVariation(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	sdk := newSDK(t, ctx)
@@ -114,6 +117,7 @@ func TestIntVariation(t *testing.T) {
 }
 
 func TestInt64Variation(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	sdk := newSDK(t, ctx)
@@ -145,6 +149,7 @@ func TestInt64Variation(t *testing.T) {
 }
 
 func TestFloat64Variation(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	sdk := newSDK(t, ctx)
@@ -176,6 +181,7 @@ func TestFloat64Variation(t *testing.T) {
 }
 
 func TestJSONVariation(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	sdk := newSDK(t, ctx)


### PR DESCRIPTION
This pull request includes significant changes to the `test/e2e/main_test.go` and `test/e2e/sdk_test.go` files, mainly focusing on the enhancement of the testing suite. The changes introduce new test cases for different variations of features and remove some redundant imports and functions.

Resolve #106.

Changes to the testing suite:

* [`test/e2e/main_test.go`](diffhunk://#diff-345f4ae23b0645edf99172a04da688e38f03f0e398ca32ec3905d4ecc325cdccR17-R43): Added several test constants for different types of feature variations, such as `String`, `Boolean`, `Int`, `Int64`, `Float`, and `Json`. This allows for more comprehensive testing of feature variations.

* [`test/e2e/sdk_test.go`](diffhunk://#diff-ce8d9b8fe48cd0b78a61d30509408338a00c599f9b0f4f968298e764fe3e6887L5-L6): Removed unused imports of `fmt` and `sync`.

* [`test/e2e/sdk_test.go`](diffhunk://#diff-ce8d9b8fe48cd0b78a61d30509408338a00c599f9b0f4f968298e764fe3e6887L15-R117): Refactored the `TestSDK` function into multiple separate test functions for different feature variations, including `TestStringVariation`, `TestBoolVariation`, `TestIntVariation`, `TestInt64Variation`, `TestFloat64Variation`, and `TestJSONVariation`. Each function now contains a slice of test cases, each with a description, a user, a feature ID, and the expected result. This makes the test cases more readable and maintainable. [[1]](diffhunk://#diff-ce8d9b8fe48cd0b78a61d30509408338a00c599f9b0f4f968298e764fe3e6887L15-R117) [[2]](diffhunk://#diff-ce8d9b8fe48cd0b78a61d30509408338a00c599f9b0f4f968298e764fe3e6887L25-R256)