### PR TITLE
chore: add new metrics events to handle unknown errors

### DIFF
--- a/pkg/bucketeer/event/processor.go
+++ b/pkg/bucketeer/event/processor.go
@@ -266,8 +266,8 @@ func (p *processor) pushTimeoutErrorMetricsEvent(ctx context.Context, api model.
 	}
 }
 
-func (p *processor) pushInternalSDKErrorMetricsEvent(ctx context.Context, api model.APIID) {
-	iecMetricsEvt := model.NewInternalSDKErrorMetricsEvent(p.tag, api)
+func (p *processor) pushInternalSDKErrorMetricsEvent(ctx context.Context, api model.APIID, err error) {
+	iecMetricsEvt := model.NewInternalSDKErrorMetricsEvent(p.tag, api, err.Error())
 	encodedIECMetricsEvt, err := json.Marshal(iecMetricsEvt)
 	if err != nil {
 		p.loggers.Errorf("bucketeer/event: pushInternalSDKErrorMetricsEvent failed (err: %v, tag: %s)", err, p.tag)
@@ -285,37 +285,35 @@ func (p *processor) pushInternalSDKErrorMetricsEvent(ctx context.Context, api mo
 	}
 }
 
-func (p *processor) pushErrorStatusCodeMetricsEvent(ctx context.Context, api model.APIID, code int) {
+func (p *processor) pushErrorStatusCodeMetricsEvent(ctx context.Context, api model.APIID, code int, err error) {
 	var evt interface{}
-	switch code {
-	case http.StatusBadRequest:
+	switch {
+	// Update error metrics report
+	// https://github.com/bucketeer-io/bucketeer/issues/799
+	case 300 <= code && code < 400:
+		evt = model.NewRedirectionRequestErrorMetricsEvent(p.tag, api, code)
+	case code == http.StatusBadRequest:
 		evt = model.NewBadRequestErrorMetricsEvent(p.tag, api)
-	case http.StatusUnauthorized:
+	case code == http.StatusUnauthorized:
 		evt = model.NewUnauthorizedErrorMetricsEvent(p.tag, api)
-	case http.StatusForbidden:
+	case code == http.StatusForbidden:
 		evt = model.NewForbiddenErrorMetricsEvent(p.tag, api)
-	case http.StatusNotFound:
+	case code == http.StatusNotFound:
 		evt = model.NewNotFoundErrorMetricsEvent(p.tag, api)
-	case http.StatusMethodNotAllowed:
-		evt = model.NewInternalSDKErrorMetricsEvent(p.tag, api)
-	case http.StatusRequestTimeout:
+	case code == http.StatusMethodNotAllowed:
+		evt = model.NewInternalSDKErrorMetricsEvent(p.tag, api, err.Error())
+	case code == http.StatusRequestTimeout:
 		evt = model.NewTimeoutErrorMetricsEvent(p.tag, api)
-	case http.StatusRequestEntityTooLarge:
+	case code == http.StatusRequestEntityTooLarge:
 		evt = model.NewPayloadTooLargeErrorMetricsEvent(p.tag, api)
-	case 499:
+	case code == 499:
 		evt = model.NewClientClosedRequestErrorMetricsEvent(p.tag, api)
-	case http.StatusInternalServerError:
+	case code == http.StatusInternalServerError:
 		evt = model.NewInternalServerErrorMetricsEvent(p.tag, api)
-	case http.StatusServiceUnavailable, http.StatusBadGateway:
+	case code == http.StatusServiceUnavailable || code == http.StatusBadGateway:
 		evt = model.NewServiceUnavailableErrorMetricsEvent(p.tag, api)
 	default:
-		// Update error metrics report
-		// https://github.com/bucketeer-io/bucketeer/issues/799
-		if 300 <= code && code < 400 {
-			evt = model.NewRedirectionRequestErrorMetricsEvent(p.tag, api)
-		} else {
-			evt = model.NewUnknownErrorMetricsEvent(p.tag, code, api)
-		}
+		evt = model.NewUnknownErrorMetricsEvent(p.tag, code, err.Error(), api)
 	}
 	encodedESCMetricsEvt, err := json.Marshal(evt)
 	if err != nil {
@@ -457,13 +455,13 @@ func (p *processor) PushErrorEvent(ctx context.Context, err error, apiID model.A
 		case os.IsTimeout(err):
 			p.pushTimeoutErrorMetricsEvent(ctx, apiID)
 		default:
-			p.pushInternalSDKErrorMetricsEvent(ctx, apiID)
+			p.pushInternalSDKErrorMetricsEvent(ctx, apiID, err)
 		}
 		return
 	}
 	if code == http.StatusGatewayTimeout {
 		p.pushTimeoutErrorMetricsEvent(ctx, apiID)
 	} else {
-		p.pushErrorStatusCodeMetricsEvent(ctx, apiID, code)
+		p.pushErrorStatusCodeMetricsEvent(ctx, apiID, code, err)
 	}
 }

--- a/pkg/bucketeer/event/processor_test.go
+++ b/pkg/bucketeer/event/processor_test.go
@@ -153,7 +153,7 @@ func TestPushInternalSDKErrorMetricsEvent(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestPushErrorStatusCodeMetricsEvent(t *testing.T) {
+func TestPushErrorStatusInternalServerErrorMetricsEvent(t *testing.T) {
 	t.Parallel()
 	p := newProcessorForTestPushEvent(t, 10)
 	p.pushErrorStatusCodeMetricsEvent(context.Background(), model.GetEvaluation, http.StatusInternalServerError)
@@ -164,6 +164,83 @@ func TestPushErrorStatusCodeMetricsEvent(t *testing.T) {
 	iseMetricsEvt := &model.InternalServerErrorMetricsEvent{}
 	err = json.Unmarshal(metricsEvt.Event, iseMetricsEvt)
 	assert.NoError(t, err)
+	assert.Equal(t, model.GetEvaluation, iseMetricsEvt.APIID)
+	assert.Equal(t, model.InternalServerErrorMetricsEventType, iseMetricsEvt.Type)
+}
+
+func TestPushErrorStatusMethodNotAllowedMetricsEvent(t *testing.T) {
+	t.Parallel()
+	p := newProcessorForTestPushEvent(t, 10)
+	p.pushErrorStatusCodeMetricsEvent(context.Background(), model.GetEvaluation, http.StatusMethodNotAllowed)
+	evt := <-p.evtQueue.eventCh()
+	metricsEvt := &model.MetricsEvent{}
+	err := json.Unmarshal(evt.Event, metricsEvt)
+	assert.NoError(t, err)
+	iseMetricsEvt := &model.InternalSDKErrorMetricsEvent{}
+	err = json.Unmarshal(metricsEvt.Event, iseMetricsEvt)
+	assert.NoError(t, err)
+	assert.Equal(t, model.GetEvaluation, iseMetricsEvt.APIID)
+	assert.Equal(t, model.InternalSDKErrorMetricsEventType, iseMetricsEvt.Type)
+}
+
+func TestPushErrorStatusRequestTimeoutMetricsEvent(t *testing.T) {
+	t.Parallel()
+	p := newProcessorForTestPushEvent(t, 10)
+	p.pushErrorStatusCodeMetricsEvent(context.Background(), model.GetEvaluation, http.StatusRequestTimeout)
+	evt := <-p.evtQueue.eventCh()
+	metricsEvt := &model.MetricsEvent{}
+	err := json.Unmarshal(evt.Event, metricsEvt)
+	assert.NoError(t, err)
+	iseMetricsEvt := &model.TimeoutErrorMetricsEvent{}
+	err = json.Unmarshal(metricsEvt.Event, iseMetricsEvt)
+	assert.NoError(t, err)
+	assert.Equal(t, model.GetEvaluation, iseMetricsEvt.APIID)
+	assert.Equal(t, model.TimeoutErrorMetricsEventType, iseMetricsEvt.Type)
+}
+
+func TestPushErrorStatusRequestEntityTooLargeMetricsEvent(t *testing.T) {
+	t.Parallel()
+	p := newProcessorForTestPushEvent(t, 10)
+	p.pushErrorStatusCodeMetricsEvent(context.Background(), model.GetEvaluation, http.StatusRequestEntityTooLarge)
+	evt := <-p.evtQueue.eventCh()
+	metricsEvt := &model.MetricsEvent{}
+	err := json.Unmarshal(evt.Event, metricsEvt)
+	assert.NoError(t, err)
+	iseMetricsEvt := &model.PayloadTooLargeErrorMetricsEvent{}
+	err = json.Unmarshal(metricsEvt.Event, iseMetricsEvt)
+	assert.NoError(t, err)
+	assert.Equal(t, model.GetEvaluation, iseMetricsEvt.APIID)
+	assert.Equal(t, model.PayloadTooLargeErrorMetricsEventType, iseMetricsEvt.Type)
+}
+
+func TestPushErrorStatusBadGatewayMetricsEvent(t *testing.T) {
+	t.Parallel()
+	p := newProcessorForTestPushEvent(t, 10)
+	p.pushErrorStatusCodeMetricsEvent(context.Background(), model.GetEvaluation, http.StatusBadGateway)
+	evt := <-p.evtQueue.eventCh()
+	metricsEvt := &model.MetricsEvent{}
+	err := json.Unmarshal(evt.Event, metricsEvt)
+	assert.NoError(t, err)
+	iseMetricsEvt := &model.ServiceUnavailableErrorMetricsEvent{}
+	err = json.Unmarshal(metricsEvt.Event, iseMetricsEvt)
+	assert.NoError(t, err)
+	assert.Equal(t, model.GetEvaluation, iseMetricsEvt.APIID)
+	assert.Equal(t, model.ServiceUnavailableErrorMetricsEventType, iseMetricsEvt.Type)
+}
+
+func TestPushErrorRedirectionRequestErrorMetricsEvent(t *testing.T) {
+	t.Parallel()
+	p := newProcessorForTestPushEvent(t, 10)
+	p.pushErrorStatusCodeMetricsEvent(context.Background(), model.GetEvaluation, 333)
+	evt := <-p.evtQueue.eventCh()
+	metricsEvt := &model.MetricsEvent{}
+	err := json.Unmarshal(evt.Event, metricsEvt)
+	assert.NoError(t, err)
+	iseMetricsEvt := &model.RedirectionRequestErrorMetricsEvent{}
+	err = json.Unmarshal(metricsEvt.Event, iseMetricsEvt)
+	assert.NoError(t, err)
+	assert.Equal(t, model.GetEvaluation, iseMetricsEvt.APIID)
+	assert.Equal(t, model.RedirectionRequestErrorMetricsEventType, iseMetricsEvt.Type)
 }
 
 func TestPushErrorEventWhenNetworkError(t *testing.T) {

--- a/pkg/bucketeer/event/processor_test.go
+++ b/pkg/bucketeer/event/processor_test.go
@@ -153,7 +153,7 @@ func TestPushInternalSDKErrorMetricsEvent(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestPushErrorStatusInternalServerErrorMetricsEvent(t *testing.T) {
+func TestPushErrorStatusCodeMetricsEventInternalServerError(t *testing.T) {
 	t.Parallel()
 	p := newProcessorForTestPushEvent(t, 10)
 	p.pushErrorStatusCodeMetricsEvent(context.Background(), model.GetEvaluation, http.StatusInternalServerError)
@@ -168,7 +168,7 @@ func TestPushErrorStatusInternalServerErrorMetricsEvent(t *testing.T) {
 	assert.Equal(t, model.InternalServerErrorMetricsEventType, iseMetricsEvt.Type)
 }
 
-func TestPushErrorStatusMethodNotAllowedMetricsEvent(t *testing.T) {
+func TestPushErrorStatusCodeMetricsEventMethodNotAllowed(t *testing.T) {
 	t.Parallel()
 	p := newProcessorForTestPushEvent(t, 10)
 	p.pushErrorStatusCodeMetricsEvent(context.Background(), model.GetEvaluation, http.StatusMethodNotAllowed)
@@ -183,7 +183,7 @@ func TestPushErrorStatusMethodNotAllowedMetricsEvent(t *testing.T) {
 	assert.Equal(t, model.InternalSDKErrorMetricsEventType, iseMetricsEvt.Type)
 }
 
-func TestPushErrorStatusRequestTimeoutMetricsEvent(t *testing.T) {
+func TestPushErrorStatusCodeMetricsEventRequestTimeout(t *testing.T) {
 	t.Parallel()
 	p := newProcessorForTestPushEvent(t, 10)
 	p.pushErrorStatusCodeMetricsEvent(context.Background(), model.GetEvaluation, http.StatusRequestTimeout)
@@ -198,7 +198,7 @@ func TestPushErrorStatusRequestTimeoutMetricsEvent(t *testing.T) {
 	assert.Equal(t, model.TimeoutErrorMetricsEventType, iseMetricsEvt.Type)
 }
 
-func TestPushErrorStatusRequestEntityTooLargeMetricsEvent(t *testing.T) {
+func TestPushErrorStatusCodeMetricsEventRequestEntityTooLarge(t *testing.T) {
 	t.Parallel()
 	p := newProcessorForTestPushEvent(t, 10)
 	p.pushErrorStatusCodeMetricsEvent(context.Background(), model.GetEvaluation, http.StatusRequestEntityTooLarge)
@@ -213,7 +213,7 @@ func TestPushErrorStatusRequestEntityTooLargeMetricsEvent(t *testing.T) {
 	assert.Equal(t, model.PayloadTooLargeErrorMetricsEventType, iseMetricsEvt.Type)
 }
 
-func TestPushErrorStatusBadGatewayMetricsEvent(t *testing.T) {
+func TestPushErrorStatusCodeMetricsEventBadGateway(t *testing.T) {
 	t.Parallel()
 	p := newProcessorForTestPushEvent(t, 10)
 	p.pushErrorStatusCodeMetricsEvent(context.Background(), model.GetEvaluation, http.StatusBadGateway)
@@ -228,7 +228,7 @@ func TestPushErrorStatusBadGatewayMetricsEvent(t *testing.T) {
 	assert.Equal(t, model.ServiceUnavailableErrorMetricsEventType, iseMetricsEvt.Type)
 }
 
-func TestPushErrorRedirectionRequestErrorMetricsEvent(t *testing.T) {
+func TestPushErrorStatusCodeMetricsEventRedirectionRequestError(t *testing.T) {
 	t.Parallel()
 	p := newProcessorForTestPushEvent(t, 10)
 	p.pushErrorStatusCodeMetricsEvent(context.Background(), model.GetEvaluation, 333)

--- a/pkg/bucketeer/model/event_test.go
+++ b/pkg/bucketeer/model/event_test.go
@@ -20,6 +20,7 @@ const (
 	sizeByte       int32 = 1000
 	featureID            = "fid"
 	errorStatus          = 333
+	errorMessage         = "error"
 )
 
 func TestNewEvent(t *testing.T) {

--- a/pkg/bucketeer/model/event_test.go
+++ b/pkg/bucketeer/model/event_test.go
@@ -19,6 +19,7 @@ const (
 	variationValue       = "value"
 	sizeByte       int32 = 1000
 	featureID            = "fid"
+	errorStatus          = 333
 )
 
 func TestNewEvent(t *testing.T) {

--- a/pkg/bucketeer/model/internal_sdk_error_metrics_event.go
+++ b/pkg/bucketeer/model/internal_sdk_error_metrics_event.go
@@ -9,10 +9,10 @@ type InternalSDKErrorMetricsEvent struct {
 //nolint:lll
 const InternalSDKErrorMetricsEventType metricsDetailEventType = "type.googleapis.com/bucketeer.event.client.InternalSdkErrorMetricsEvent"
 
-func NewInternalSDKErrorMetricsEvent(tag string, api APIID) *InternalSDKErrorMetricsEvent {
+func NewInternalSDKErrorMetricsEvent(tag string, api APIID, message string) *InternalSDKErrorMetricsEvent {
 	return &InternalSDKErrorMetricsEvent{
 		APIID:  api,
-		Labels: map[string]string{"tag": tag},
+		Labels: map[string]string{"tag": tag, "error_message": message},
 		Type:   InternalSDKErrorMetricsEventType,
 	}
 }

--- a/pkg/bucketeer/model/internal_sdk_error_metrics_event_test.go
+++ b/pkg/bucketeer/model/internal_sdk_error_metrics_event_test.go
@@ -8,8 +8,9 @@ import (
 
 func TestNewInternalSDKErrorMetricsEvent(t *testing.T) {
 	t.Parallel()
-	e := NewInternalSDKErrorMetricsEvent(tag, GetEvaluation)
+	e := NewInternalSDKErrorMetricsEvent(tag, GetEvaluation, errorMessage)
 	assert.IsType(t, &InternalSDKErrorMetricsEvent{}, e)
 	assert.Equal(t, tag, e.Labels["tag"])
+	assert.Equal(t, errorMessage, e.Labels["error_message"])
 	assert.Equal(t, InternalSDKErrorMetricsEventType, e.Type)
 }

--- a/pkg/bucketeer/model/status.go
+++ b/pkg/bucketeer/model/status.go
@@ -11,6 +11,8 @@ const (
 	ClientClosedRequestErrorMetricsEventType errorStatusEventType = "type.googleapis.com/bucketeer.event.client.ClientClosedRequestErrorMetricsEvent"
 	InternalServerErrorMetricsEventType      errorStatusEventType = "type.googleapis.com/bucketeer.event.client.InternalServerErrorMetricsEvent"
 	ServiceUnavailableErrorMetricsEventType  errorStatusEventType = "type.googleapis.com/bucketeer.event.client.ServiceUnavailableErrorMetricsEvent"
+	PayloadTooLargeErrorMetricsEventType     errorStatusEventType = "type.googleapis.com/bucketeer.event.client.PayloadTooLargeExceptionEvent"
+	RedirectionRequestErrorMetricsEventType  errorStatusEventType = "type.googleapis.com/bucketeer.event.client.RedirectionRequestExceptionEvent"
 )
 
 // HTTP Mapping: 400 Bad Request
@@ -115,5 +117,33 @@ func NewServiceUnavailableErrorMetricsEvent(tag string, api APIID) *ServiceUnava
 		APIID:  api,
 		Labels: map[string]string{"tag": tag},
 		Type:   ServiceUnavailableErrorMetricsEventType,
+	}
+}
+
+type PayloadTooLargeErrorMetricsEvent struct {
+	APIID  APIID                `json:"apiId,omitempty"`
+	Labels map[string]string    `json:"labels,omitempty"`
+	Type   errorStatusEventType `json:"@type,omitempty"`
+}
+
+func NewPayloadTooLargeErrorMetricsEvent(tag string, api APIID) *PayloadTooLargeErrorMetricsEvent {
+	return &PayloadTooLargeErrorMetricsEvent{
+		APIID:  api,
+		Labels: map[string]string{"tag": tag},
+		Type:   PayloadTooLargeErrorMetricsEventType,
+	}
+}
+
+type RedirectionRequestErrorMetricsEvent struct {
+	APIID  APIID                `json:"apiId,omitempty"`
+	Labels map[string]string    `json:"labels,omitempty"`
+	Type   errorStatusEventType `json:"@type,omitempty"`
+}
+
+func NewRedirectionRequestErrorMetricsEvent(tag string, api APIID) *RedirectionRequestErrorMetricsEvent {
+	return &RedirectionRequestErrorMetricsEvent{
+		APIID:  api,
+		Labels: map[string]string{"tag": tag},
+		Type:   RedirectionRequestErrorMetricsEventType,
 	}
 }

--- a/pkg/bucketeer/model/status.go
+++ b/pkg/bucketeer/model/status.go
@@ -1,5 +1,7 @@
 package model
 
+import "strconv"
+
 type errorStatusEventType string
 
 //nolint:lll
@@ -140,10 +142,10 @@ type RedirectionRequestErrorMetricsEvent struct {
 	Type   errorStatusEventType `json:"@type,omitempty"`
 }
 
-func NewRedirectionRequestErrorMetricsEvent(tag string, api APIID) *RedirectionRequestErrorMetricsEvent {
+func NewRedirectionRequestErrorMetricsEvent(tag string, api APIID, code int) *RedirectionRequestErrorMetricsEvent {
 	return &RedirectionRequestErrorMetricsEvent{
 		APIID:  api,
-		Labels: map[string]string{"tag": tag},
+		Labels: map[string]string{"tag": tag, "response_code": strconv.Itoa(code)},
 		Type:   RedirectionRequestErrorMetricsEventType,
 	}
 }

--- a/pkg/bucketeer/model/status_test.go
+++ b/pkg/bucketeer/model/status_test.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -72,8 +73,9 @@ func TestNewPayloadTooLargeErrorMetricsEvent(t *testing.T) {
 
 func TestNewRedirectionRequestErrorMetricsEvent(t *testing.T) {
 	t.Parallel()
-	e := NewRedirectionRequestErrorMetricsEvent(tag, GetEvaluation)
+	e := NewRedirectionRequestErrorMetricsEvent(tag, GetEvaluation, errorStatus)
 	assert.IsType(t, &RedirectionRequestErrorMetricsEvent{}, e)
 	assert.Equal(t, tag, e.Labels["tag"])
+	assert.Equal(t, fmt.Sprint(errorStatus), e.Labels["response_code"])
 	assert.Equal(t, RedirectionRequestErrorMetricsEventType, e.Type)
 }

--- a/pkg/bucketeer/model/status_test.go
+++ b/pkg/bucketeer/model/status_test.go
@@ -61,3 +61,19 @@ func TestNewServiceUnavailableErrorMetricsEvent(t *testing.T) {
 	assert.Equal(t, tag, e.Labels["tag"])
 	assert.Equal(t, ServiceUnavailableErrorMetricsEventType, e.Type)
 }
+
+func TestNewPayloadTooLargeErrorMetricsEvent(t *testing.T) {
+	t.Parallel()
+	e := NewPayloadTooLargeErrorMetricsEvent(tag, GetEvaluation)
+	assert.IsType(t, &PayloadTooLargeErrorMetricsEvent{}, e)
+	assert.Equal(t, tag, e.Labels["tag"])
+	assert.Equal(t, PayloadTooLargeErrorMetricsEventType, e.Type)
+}
+
+func TestNewRedirectionRequestErrorMetricsEvent(t *testing.T) {
+	t.Parallel()
+	e := NewRedirectionRequestErrorMetricsEvent(tag, GetEvaluation)
+	assert.IsType(t, &RedirectionRequestErrorMetricsEvent{}, e)
+	assert.Equal(t, tag, e.Labels["tag"])
+	assert.Equal(t, RedirectionRequestErrorMetricsEventType, e.Type)
+}

--- a/pkg/bucketeer/model/unknown_error_metrics_event.go
+++ b/pkg/bucketeer/model/unknown_error_metrics_event.go
@@ -1,5 +1,7 @@
 package model
 
+import "strconv"
+
 //nolint:lll
 const UnknownErrorMetricsEventType metricsDetailEventType = "type.googleapis.com/bucketeer.event.client.UnknownErrorMetricsEvent"
 
@@ -9,10 +11,10 @@ type UnknownErrorMetricsEvent struct {
 	Type   metricsDetailEventType `json:"@type,omitempty"`
 }
 
-func NewUnknownErrorMetricsEvent(tag string, api APIID) *UnknownErrorMetricsEvent {
+func NewUnknownErrorMetricsEvent(tag string, code int, api APIID) *UnknownErrorMetricsEvent {
 	return &UnknownErrorMetricsEvent{
 		APIID:  api,
-		Labels: map[string]string{"tag": tag},
+		Labels: map[string]string{"tag": tag, "response_code": strconv.Itoa(code)},
 		Type:   UnknownErrorMetricsEventType,
 	}
 }

--- a/pkg/bucketeer/model/unknown_error_metrics_event.go
+++ b/pkg/bucketeer/model/unknown_error_metrics_event.go
@@ -11,10 +11,10 @@ type UnknownErrorMetricsEvent struct {
 	Type   metricsDetailEventType `json:"@type,omitempty"`
 }
 
-func NewUnknownErrorMetricsEvent(tag string, code int, api APIID) *UnknownErrorMetricsEvent {
+func NewUnknownErrorMetricsEvent(tag string, code int, message string, api APIID) *UnknownErrorMetricsEvent {
 	return &UnknownErrorMetricsEvent{
 		APIID:  api,
-		Labels: map[string]string{"tag": tag, "response_code": strconv.Itoa(code)},
+		Labels: map[string]string{"tag": tag, "response_code": strconv.Itoa(code), "error_message": message},
 		Type:   UnknownErrorMetricsEventType,
 	}
 }

--- a/pkg/bucketeer/model/unknown_error_metrics_event_test.go
+++ b/pkg/bucketeer/model/unknown_error_metrics_event_test.go
@@ -9,9 +9,10 @@ import (
 
 func TestNewUnknownErrorMetricsEvent(t *testing.T) {
 	t.Parallel()
-	e := NewUnknownErrorMetricsEvent(tag, errorStatus, GetEvaluation)
+	e := NewUnknownErrorMetricsEvent(tag, errorStatus, errorMessage, GetEvaluation)
 	assert.IsType(t, &UnknownErrorMetricsEvent{}, e)
 	assert.Equal(t, tag, e.Labels["tag"])
+	assert.Equal(t, errorMessage, e.Labels["error_message"])
 	assert.Equal(t, fmt.Sprint(errorStatus), e.Labels["response_code"])
 	assert.Equal(t, UnknownErrorMetricsEventType, e.Type)
 }

--- a/pkg/bucketeer/model/unknown_error_metrics_event_test.go
+++ b/pkg/bucketeer/model/unknown_error_metrics_event_test.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -8,8 +9,9 @@ import (
 
 func TestNewUnknownErrorMetricsEvent(t *testing.T) {
 	t.Parallel()
-	e := NewUnknownErrorMetricsEvent(tag, GetEvaluation)
+	e := NewUnknownErrorMetricsEvent(tag, errorStatus, GetEvaluation)
 	assert.IsType(t, &UnknownErrorMetricsEvent{}, e)
 	assert.Equal(t, tag, e.Labels["tag"])
+	assert.Equal(t, fmt.Sprint(errorStatus), e.Labels["response_code"])
 	assert.Equal(t, UnknownErrorMetricsEventType, e.Type)
 }


### PR DESCRIPTION

This pull request primarily focuses on improving error handling and reporting in the `bucketeer` package. The changes include expanding the types of HTTP status codes that are handled, adding new error metrics events, and updating the associated tests to cover these new cases.

resolve https://github.com/bucketeer-io/bucketeer/issues/799

Error handling improvements:

* [`pkg/bucketeer/event/processor.go`](diffhunk://#diff-40be257af42e6fcbb9b3cb9b1e41df34ac9d1b83ee2c32a91a4722389b196060R299-R318): Expanded the types of HTTP status codes that are handled in the `pushErrorStatusCodeMetricsEvent` function. New status codes include `http.StatusMethodNotAllowed`, `http.StatusRequestTimeout`, `http.StatusRequestEntityTooLarge`, and `http.StatusBadGateway`. Also, the handling of redirection status codes (300-399) and unknown status codes has been improved.

Error metrics event additions:

* [`pkg/bucketeer/model/status.go`](diffhunk://#diff-2b8e3679b2e8fa2aa83ff49f0b7d704d6e573eb9ff6e6d88c66ead2b5a9a1852R14-R15): Added new types of error metrics events: `PayloadTooLargeErrorMetricsEvent` and `RedirectionRequestErrorMetricsEvent`. These new events are used in the expanded error handling in `processor.go`. [[1]](diffhunk://#diff-2b8e3679b2e8fa2aa83ff49f0b7d704d6e573eb9ff6e6d88c66ead2b5a9a1852R14-R15) [[2]](diffhunk://#diff-2b8e3679b2e8fa2aa83ff49f0b7d704d6e573eb9ff6e6d88c66ead2b5a9a1852R122-R149)
* [`pkg/bucketeer/model/unknown_error_metrics_event.go`](diffhunk://#diff-216e7005cf3185f0549e2c6163a579eed63effe5148f510bcf50a9da9e6a5d82L12-R17): Modified the `NewUnknownErrorMetricsEvent` function to include the response code in the event's labels.

Test updates:

* [`pkg/bucketeer/event/processor_test.go`](diffhunk://#diff-9f2a3d0df472e191911897e05bd0292bdc63c9d6be06d298549b07c917e6f53cL156-R156): Updated the `TestPushErrorStatusCodeMetricsEvent` function and added new test functions to cover the new status codes and error metrics events. [[1]](diffhunk://#diff-9f2a3d0df472e191911897e05bd0292bdc63c9d6be06d298549b07c917e6f53cL156-R156) [[2]](diffhunk://#diff-9f2a3d0df472e191911897e05bd0292bdc63c9d6be06d298549b07c917e6f53cR167-R243)
* [`pkg/bucketeer/model/status_test.go`](diffhunk://#diff-2894775564f5f21bdc4ae3d590e6879751c334a2d625c5e0c8e39a7a7b45a6a6R64-R79): Added new test functions for the new error metrics events.
* [`pkg/bucketeer/model/unknown_error_metrics_event_test.go`](diffhunk://#diff-aa47930c0705742c76254e9703d801f3a0e4dc5785f819e2c447f3a245c58275R4-R15): Updated the `TestNewUnknownErrorMetricsEvent` function to check the new response code label.