### PR TITLE
chore: add SourceID and SDKVersion to the required request

### DIFF
--- a/pkg/bucketeer/event/processor.go
+++ b/pkg/bucketeer/event/processor.go
@@ -414,7 +414,7 @@ func (p *processor) flushEvents(ctx context.Context, events []*model.Event) {
 	if len(events) == 0 {
 		return
 	}
-	res, _, err := p.apiClient.RegisterEvents(&model.RegisterEventsRequest{Events: events})
+	res, _, err := p.apiClient.RegisterEvents(model.NewRegisterEventsRequest(events))
 	if err != nil {
 		p.loggers.Debugf("bucketeer/event: failed to register events: %v", err)
 		// Re-push all events to the event queue.

--- a/pkg/bucketeer/event/processor_test.go
+++ b/pkg/bucketeer/event/processor_test.go
@@ -472,7 +472,7 @@ func TestFlushEvents(t *testing.T) {
 		{
 			desc: "do nothing when events length is 0",
 			setup: func(p *processor, events []*model.Event) {
-				p.apiClient.(*mockapi.MockClient).EXPECT().RegisterEvents(&model.RegisterEventsRequest{Events: events}).Times(0)
+				p.apiClient.(*mockapi.MockClient).EXPECT().RegisterEvents(model.NewRegisterEventsRequest(events)).Times(0)
 			},
 			events:           make([]*model.Event, 0, 10),
 			expectedQueueLen: 0,
@@ -480,7 +480,7 @@ func TestFlushEvents(t *testing.T) {
 		{
 			desc: "re-push all events when failed to register events",
 			setup: func(p *processor, events []*model.Event) {
-				p.apiClient.(*mockapi.MockClient).EXPECT().RegisterEvents(&model.RegisterEventsRequest{Events: events}).Return(
+				p.apiClient.(*mockapi.MockClient).EXPECT().RegisterEvents(model.NewRegisterEventsRequest(events)).Return(
 					nil,
 					0,
 					api.NewErrStatus(http.StatusInternalServerError),
@@ -493,7 +493,7 @@ func TestFlushEvents(t *testing.T) {
 			desc: "faled to re-push all events when failed to register events if queue is closed",
 			setup: func(p *processor, events []*model.Event) {
 				p.evtQueue.close()
-				p.apiClient.(*mockapi.MockClient).EXPECT().RegisterEvents(&model.RegisterEventsRequest{Events: events}).Return(
+				p.apiClient.(*mockapi.MockClient).EXPECT().RegisterEvents(model.NewRegisterEventsRequest(events)).Return(
 					nil,
 					0,
 					api.NewErrStatus(http.StatusInternalServerError),
@@ -505,7 +505,7 @@ func TestFlushEvents(t *testing.T) {
 		{
 			desc: "re-push events when register events res contains retriable errors",
 			setup: func(p *processor, events []*model.Event) {
-				p.apiClient.(*mockapi.MockClient).EXPECT().RegisterEvents(&model.RegisterEventsRequest{Events: events}).Return(
+				p.apiClient.(*mockapi.MockClient).EXPECT().RegisterEvents(model.NewRegisterEventsRequest(events)).Return(
 					&model.RegisterEventsResponse{
 						Errors: map[string]*model.RegisterEventsResponseError{
 							"id-0": {Retriable: true, Message: "retriable"},
@@ -523,7 +523,7 @@ func TestFlushEvents(t *testing.T) {
 			desc: "faled to re-push events when register events res contains retriable errors if queue is closed",
 			setup: func(p *processor, events []*model.Event) {
 				p.evtQueue.close()
-				p.apiClient.(*mockapi.MockClient).EXPECT().RegisterEvents(&model.RegisterEventsRequest{Events: events}).Return(
+				p.apiClient.(*mockapi.MockClient).EXPECT().RegisterEvents(model.NewRegisterEventsRequest(events)).Return(
 					&model.RegisterEventsResponse{
 						Errors: map[string]*model.RegisterEventsResponseError{
 							"id-0": {Retriable: true, Message: "retriable"},
@@ -540,7 +540,7 @@ func TestFlushEvents(t *testing.T) {
 		{
 			desc: "success",
 			setup: func(p *processor, events []*model.Event) {
-				p.apiClient.(*mockapi.MockClient).EXPECT().RegisterEvents(&model.RegisterEventsRequest{Events: events}).Return(
+				p.apiClient.(*mockapi.MockClient).EXPECT().RegisterEvents(model.NewRegisterEventsRequest(events)).Return(
 					&model.RegisterEventsResponse{
 						Errors: make(map[string]*model.RegisterEventsResponseError),
 					},

--- a/pkg/bucketeer/model/get_evaluation_request.go
+++ b/pkg/bucketeer/model/get_evaluation_request.go
@@ -1,19 +1,24 @@
 package model
 
-import "github.com/bucketeer-io/go-server-sdk/pkg/bucketeer/user"
+import (
+	"github.com/bucketeer-io/go-server-sdk/pkg/bucketeer/user"
+	"github.com/bucketeer-io/go-server-sdk/pkg/bucketeer/version"
+)
 
 type GetEvaluationRequest struct {
-	Tag       string       `json:"tag,omitempty"`
-	User      *user.User   `json:"user,omitempty"`
-	FeatureID string       `json:"featureId,omitempty"`
-	SourceID  SourceIDType `json:"sourceId,omitempty"`
+	Tag        string       `json:"tag,omitempty"`
+	User       *user.User   `json:"user,omitempty"`
+	FeatureID  string       `json:"featureId,omitempty"`
+	SourceID   SourceIDType `json:"sourceId,omitempty"`
+	SDKVersion string       `json:"sdkVersion,omitempty"`
 }
 
 func NewGetEvaluationRequest(tag, featureID string, user *user.User) *GetEvaluationRequest {
 	return &GetEvaluationRequest{
-		Tag:       tag,
-		User:      user,
-		FeatureID: featureID,
-		SourceID:  SourceIDGoServer,
+		Tag:        tag,
+		User:       user,
+		FeatureID:  featureID,
+		SourceID:   SourceIDGoServer,
+		SDKVersion: version.SDKVersion,
 	}
 }

--- a/pkg/bucketeer/model/get_evaluation_request_test.go
+++ b/pkg/bucketeer/model/get_evaluation_request_test.go
@@ -3,6 +3,7 @@ package model
 import (
 	"testing"
 
+	"github.com/bucketeer-io/go-server-sdk/pkg/bucketeer/version"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -14,4 +15,5 @@ func TestNewGetEvaluationRequest(t *testing.T) {
 	assert.Equal(t, SourceIDGoServer, e.SourceID)
 	assert.Equal(t, featureID, e.FeatureID)
 	assert.Equal(t, id, e.User.ID)
+	assert.Equal(t, version.SDKVersion, e.SDKVersion)
 }

--- a/pkg/bucketeer/model/register_events_request.go
+++ b/pkg/bucketeer/model/register_events_request.go
@@ -1,5 +1,17 @@
 package model
 
+import "github.com/bucketeer-io/go-server-sdk/pkg/bucketeer/version"
+
 type RegisterEventsRequest struct {
-	Events []*Event `json:"events,omitempty"`
+	Events     []*Event     `json:"events,omitempty"`
+	SDKVersion string       `json:"sdkVersion,omitempty"`
+	SourceID   SourceIDType `json:"sourceId,omitempty"`
+}
+
+func NewRegisterEventsRequest(event []*Event) *RegisterEventsRequest {
+	return &RegisterEventsRequest{
+		Events:     event,
+		SDKVersion: version.SDKVersion,
+		SourceID:   SourceIDGoServer,
+	}
 }

--- a/pkg/bucketeer/model/register_events_request_test.go
+++ b/pkg/bucketeer/model/register_events_request_test.go
@@ -1,0 +1,18 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/bucketeer-io/go-server-sdk/pkg/bucketeer/version"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewRegisterEventsRequest(t *testing.T) {
+	t.Parallel()
+	event := []*Event{&Event{}}
+	r := NewRegisterEventsRequest(event)
+	assert.IsType(t, &RegisterEventsRequest{}, r)
+	assert.Equal(t, event, r.Events)
+	assert.Equal(t, SourceIDGoServer, r.SourceID)
+	assert.Equal(t, version.SDKVersion, r.SDKVersion)
+}

--- a/pkg/bucketeer/sdk.go
+++ b/pkg/bucketeer/sdk.go
@@ -79,8 +79,6 @@ type sdk struct {
 	loggers        *log.Loggers
 }
 
-const SourceIDGoServer = 5
-
 // NewSDK creates a new Bucketeer SDK.
 func NewSDK(ctx context.Context, opts ...Option) (SDK, error) {
 	dopts := defaultOptions

--- a/pkg/bucketeer/sdk_test.go
+++ b/pkg/bucketeer/sdk_test.go
@@ -40,12 +40,7 @@ func TestBoolVariation(t *testing.T) {
 			desc: "return default value when failed to get evaluation",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
 				err := api.NewErrStatus(http.StatusInternalServerError)
-				req := &model.GetEvaluationRequest{
-					Tag:       sdkTag,
-					User:      user,
-					FeatureID: featureID,
-					SourceID:  SourceIDGoServer,
-				}
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(
 					nil,
 					100, err,
@@ -69,12 +64,7 @@ func TestBoolVariation(t *testing.T) {
 		{
 			desc: "return default value when faled to parse variation",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
-				req := &model.GetEvaluationRequest{
-					Tag:       sdkTag,
-					User:      user,
-					FeatureID: featureID,
-					SourceID:  SourceIDGoServer,
-				}
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
 				res := newGetEvaluationResponse(t, featureID, "invalid")
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, 100, nil)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushLatencyMetricsEvent(
@@ -101,12 +91,7 @@ func TestBoolVariation(t *testing.T) {
 		{
 			desc: "success",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
-				req := &model.GetEvaluationRequest{
-					Tag:       sdkTag,
-					User:      user,
-					FeatureID: featureID,
-					SourceID:  SourceIDGoServer,
-				}
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
 				res := newGetEvaluationResponse(t, featureID, "true")
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, 100, nil)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushLatencyMetricsEvent(
@@ -160,12 +145,7 @@ func TestIntVariation(t *testing.T) {
 			desc: "return default value when failed to get evaluation",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
 				err := api.NewErrStatus(http.StatusInternalServerError)
-				req := &model.GetEvaluationRequest{
-					Tag:       sdkTag,
-					User:      user,
-					FeatureID: featureID,
-					SourceID:  SourceIDGoServer,
-				}
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(
 					nil,
 					100, err,
@@ -189,12 +169,7 @@ func TestIntVariation(t *testing.T) {
 		{
 			desc: "return default value when faled to parse variation",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
-				req := &model.GetEvaluationRequest{
-					Tag:       sdkTag,
-					User:      user,
-					FeatureID: featureID,
-					SourceID:  SourceIDGoServer,
-				}
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
 				res := newGetEvaluationResponse(t, featureID, "invalid")
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, 10, nil)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushLatencyMetricsEvent(
@@ -221,12 +196,7 @@ func TestIntVariation(t *testing.T) {
 		{
 			desc: "success",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
-				req := &model.GetEvaluationRequest{
-					Tag:       sdkTag,
-					User:      user,
-					FeatureID: featureID,
-					SourceID:  SourceIDGoServer,
-				}
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
 				res := newGetEvaluationResponse(t, featureID, "2")
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, 20, nil)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushLatencyMetricsEvent(
@@ -280,12 +250,7 @@ func TestInt64Variation(t *testing.T) {
 			desc: "return default value when failed to get evaluation",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
 				err := api.NewErrStatus(http.StatusInternalServerError)
-				req := &model.GetEvaluationRequest{
-					Tag:       sdkTag,
-					User:      user,
-					FeatureID: featureID,
-					SourceID:  SourceIDGoServer,
-				}
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(
 					nil,
 					100,
@@ -310,12 +275,7 @@ func TestInt64Variation(t *testing.T) {
 		{
 			desc: "return default value when faled to parse variation",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
-				req := &model.GetEvaluationRequest{
-					Tag:       sdkTag,
-					User:      user,
-					FeatureID: featureID,
-					SourceID:  SourceIDGoServer,
-				}
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
 				res := newGetEvaluationResponse(t, featureID, "invalid")
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, 5, nil)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushLatencyMetricsEvent(
@@ -342,12 +302,7 @@ func TestInt64Variation(t *testing.T) {
 		{
 			desc: "success",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
-				req := &model.GetEvaluationRequest{
-					Tag:       sdkTag,
-					User:      user,
-					FeatureID: featureID,
-					SourceID:  SourceIDGoServer,
-				}
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
 				res := newGetEvaluationResponse(t, featureID, "2")
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, 10, nil)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushLatencyMetricsEvent(
@@ -401,12 +356,7 @@ func TestFloat64Variation(t *testing.T) {
 			desc: "return default value when failed to get evaluation",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
 				err := api.NewErrStatus(http.StatusInternalServerError)
-				req := &model.GetEvaluationRequest{
-					Tag:       sdkTag,
-					User:      user,
-					FeatureID: featureID,
-					SourceID:  SourceIDGoServer,
-				}
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(
 					nil,
 					100, err,
@@ -430,12 +380,7 @@ func TestFloat64Variation(t *testing.T) {
 		{
 			desc: "return default value when faled to parse variation",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
-				req := &model.GetEvaluationRequest{
-					Tag:       sdkTag,
-					User:      user,
-					FeatureID: featureID,
-					SourceID:  SourceIDGoServer,
-				}
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
 				res := newGetEvaluationResponse(t, featureID, "invalid")
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, 100, nil)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushLatencyMetricsEvent(
@@ -462,12 +407,7 @@ func TestFloat64Variation(t *testing.T) {
 		{
 			desc: "success",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
-				req := &model.GetEvaluationRequest{
-					Tag:       sdkTag,
-					User:      user,
-					FeatureID: featureID,
-					SourceID:  SourceIDGoServer,
-				}
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
 				res := newGetEvaluationResponse(t, featureID, "2.2")
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, 100, nil)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushLatencyMetricsEvent(
@@ -521,12 +461,7 @@ func TestStringVariation(t *testing.T) {
 			desc: "return default value when failed to get evaluation",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
 				err := api.NewErrStatus(http.StatusInternalServerError)
-				req := &model.GetEvaluationRequest{
-					Tag:       sdkTag,
-					User:      user,
-					FeatureID: featureID,
-					SourceID:  SourceIDGoServer,
-				}
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(
 					nil,
 					100, err,
@@ -550,12 +485,7 @@ func TestStringVariation(t *testing.T) {
 		{
 			desc: "success",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
-				req := &model.GetEvaluationRequest{
-					Tag:       sdkTag,
-					User:      user,
-					FeatureID: featureID,
-					SourceID:  SourceIDGoServer,
-				}
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
 				res := newGetEvaluationResponse(t, featureID, "value")
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, 100, nil)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushLatencyMetricsEvent(
@@ -613,12 +543,7 @@ func TestJSONVariation(t *testing.T) {
 			desc: "failed to get evaluation",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
 				err := api.NewErrStatus(http.StatusInternalServerError)
-				req := &model.GetEvaluationRequest{
-					Tag:       sdkTag,
-					User:      user,
-					FeatureID: featureID,
-					SourceID:  SourceIDGoServer,
-				}
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(
 					nil,
 					100, err,
@@ -642,12 +567,7 @@ func TestJSONVariation(t *testing.T) {
 		{
 			desc: "faled to unmarshal variation",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
-				req := &model.GetEvaluationRequest{
-					Tag:       sdkTag,
-					User:      user,
-					FeatureID: featureID,
-					SourceID:  SourceIDGoServer,
-				}
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
 				res := newGetEvaluationResponse(t, featureID, `invalid`)
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, 100, nil)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushLatencyMetricsEvent(
@@ -674,12 +594,7 @@ func TestJSONVariation(t *testing.T) {
 		{
 			desc: "success",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
-				req := &model.GetEvaluationRequest{
-					Tag:       sdkTag,
-					User:      user,
-					FeatureID: featureID,
-					SourceID:  SourceIDGoServer,
-				}
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
 				res := newGetEvaluationResponse(t, featureID, `{"str": "str2", "int": "int2"}`)
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, 100, nil)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushLatencyMetricsEvent(
@@ -741,12 +656,7 @@ func TestGetEvaluation(t *testing.T) {
 			desc: "get evaluations returns timeout error",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
 				err := api.NewErrStatus(http.StatusGatewayTimeout)
-				req := &model.GetEvaluationRequest{
-					Tag:       sdkTag,
-					User:      user,
-					FeatureID: featureID,
-					SourceID:  SourceIDGoServer,
-				}
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(
 					nil,
 					100, err,
@@ -766,12 +676,7 @@ func TestGetEvaluation(t *testing.T) {
 			desc: "get evaluations returns internal error",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
 				err := api.NewErrStatus(http.StatusGatewayTimeout)
-				req := &model.GetEvaluationRequest{
-					Tag:       sdkTag,
-					User:      user,
-					FeatureID: featureID,
-					SourceID:  SourceIDGoServer,
-				}
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(
 					nil,
 					100, err,
@@ -790,12 +695,7 @@ func TestGetEvaluation(t *testing.T) {
 		{
 			desc: "invalid get evaluation res: res is nil",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
-				req := &model.GetEvaluationRequest{
-					Tag:       sdkTag,
-					User:      user,
-					FeatureID: featureID,
-					SourceID:  SourceIDGoServer,
-				}
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
 				var res *model.GetEvaluationResponse
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, 100, nil)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushLatencyMetricsEvent(
@@ -817,12 +717,7 @@ func TestGetEvaluation(t *testing.T) {
 		{
 			desc: "invalid get evaluation res: evaluation is nil",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
-				req := &model.GetEvaluationRequest{
-					Tag:       sdkTag,
-					User:      user,
-					FeatureID: featureID,
-					SourceID:  SourceIDGoServer,
-				}
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
 				res := newGetEvaluationResponse(t, featureID, "value")
 				res.Evaluation = nil
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, 100, nil)
@@ -845,12 +740,7 @@ func TestGetEvaluation(t *testing.T) {
 		{
 			desc: "invalid get evaluation res: feature id doesn't match",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
-				req := &model.GetEvaluationRequest{
-					Tag:       sdkTag,
-					User:      user,
-					FeatureID: featureID,
-					SourceID:  SourceIDGoServer,
-				}
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
 				res := newGetEvaluationResponse(t, "invalid-feature-id", "value")
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, 100, nil)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushLatencyMetricsEvent(
@@ -872,12 +762,7 @@ func TestGetEvaluation(t *testing.T) {
 		{
 			desc: "invalid get evaluation res: variation value is empty",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
-				req := &model.GetEvaluationRequest{
-					Tag:       sdkTag,
-					User:      user,
-					FeatureID: featureID,
-					SourceID:  SourceIDGoServer,
-				}
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
 				res := newGetEvaluationResponse(t, featureID, "")
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, 100, nil)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushLatencyMetricsEvent(
@@ -899,12 +784,7 @@ func TestGetEvaluation(t *testing.T) {
 		{
 			desc: "success",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
-				req := &model.GetEvaluationRequest{
-					Tag:       sdkTag,
-					User:      user,
-					FeatureID: featureID,
-					SourceID:  SourceIDGoServer,
-				}
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
 				res := newGetEvaluationResponse(t, featureID, "value")
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(
 					res,

--- a/test/e2e/api_test.go
+++ b/test/e2e/api_test.go
@@ -17,7 +17,7 @@ func TestGetEvaluation(t *testing.T) {
 	t.Parallel()
 	client := newAPIClient(t)
 	user := user.NewUser(userID, nil)
-	res, _, err := client.GetEvaluation(&model.GetEvaluationRequest{Tag: tag, User: user, FeatureID: featureID})
+	res, _, err := client.GetEvaluation(model.NewGetEvaluationRequest(tag, featureID, user))
 	assert.NoError(t, err)
 	assert.Equal(t, featureID, res.Evaluation.FeatureID)
 	assert.Equal(t, featureIDVariation2, res.Evaluation.VariationValue)
@@ -93,8 +93,8 @@ func TestRegisterEvents(t *testing.T) {
 	assert.NoError(t, err)
 	iesmetricsEvent, err := json.Marshal(model.NewMetricsEvent(internalServerError))
 	assert.NoError(t, err)
-	req := &model.RegisterEventsRequest{
-		Events: []*model.Event{
+	req := model.NewRegisterEventsRequest(
+		[]*model.Event{
 			{
 				ID:    newUUID(t),
 				Event: evaluationEvent,
@@ -128,7 +128,7 @@ func TestRegisterEvents(t *testing.T) {
 				Event: iesmetricsEvent,
 			},
 		},
-	}
+	)
 	res, _, err := client.RegisterEvents(req)
 	assert.NoError(t, err)
 	assert.Len(t, res.Errors, 0)


### PR DESCRIPTION
This pull request primarily involves refactoring the way events are registered and evaluated in the Bucketeer SDK. The changes include the introduction of new methods for creating `GetEvaluationRequest` and `RegisterEventsRequest` objects, the removal of the `SourceIDGoServer` constant, and updates to test cases to reflect these changes.

Part of https://github.com/bucketeer-io/bucketeer/issues/916

Changes to event registration:

* [`pkg/bucketeer/event/processor.go`](diffhunk://#diff-40be257af42e6fcbb9b3cb9b1e41df34ac9d1b83ee2c32a91a4722389b196060L417-R417): Replaced direct creation of `RegisterEventsRequest` with call to `model.NewRegisterEventsRequest(events)` in `flushEvents` method.
* [`pkg/bucketeer/event/processor_test.go`](diffhunk://#diff-9f2a3d0df472e191911897e05bd0292bdc63c9d6be06d298549b07c917e6f53cL475-R483): Updated test cases in `TestFlushEvents` to use `model.NewRegisterEventsRequest(events)` instead of directly creating `RegisterEventsRequest`. [[1]](diffhunk://#diff-9f2a3d0df472e191911897e05bd0292bdc63c9d6be06d298549b07c917e6f53cL475-R483) [[2]](diffhunk://#diff-9f2a3d0df472e191911897e05bd0292bdc63c9d6be06d298549b07c917e6f53cL496-R496) [[3]](diffhunk://#diff-9f2a3d0df472e191911897e05bd0292bdc63c9d6be06d298549b07c917e6f53cL508-R508) [[4]](diffhunk://#diff-9f2a3d0df472e191911897e05bd0292bdc63c9d6be06d298549b07c917e6f53cL526-R526) [[5]](diffhunk://#diff-9f2a3d0df472e191911897e05bd0292bdc63c9d6be06d298549b07c917e6f53cL543-R543)

Changes to evaluation requests:

* [`pkg/bucketeer/model/get_evaluation_request.go`](diffhunk://#diff-424cb080cb995a1ade65a8efce87b93530b78c7fdac8678af966d64da1c4cc3fL3-R13): Added `SDKVersion` to `GetEvaluationRequest` struct and updated `NewGetEvaluationRequest` method to include `SDKVersion`. [[1]](diffhunk://#diff-424cb080cb995a1ade65a8efce87b93530b78c7fdac8678af966d64da1c4cc3fL3-R13) [[2]](diffhunk://#diff-424cb080cb995a1ade65a8efce87b93530b78c7fdac8678af966d64da1c4cc3fR22)
* [`pkg/bucketeer/sdk_test.go`](diffhunk://#diff-f9addb460e347a9f14087936cb13b28dc2b3e5ceb87aaf61d25e5f84a4d6784dL43-R43): Updated test cases to use `model.NewGetEvaluationRequest` instead of directly creating `GetEvaluationRequest`. [[1]](diffhunk://#diff-f9addb460e347a9f14087936cb13b28dc2b3e5ceb87aaf61d25e5f84a4d6784dL43-R43) [[2]](diffhunk://#diff-f9addb460e347a9f14087936cb13b28dc2b3e5ceb87aaf61d25e5f84a4d6784dL72-R67) [[3]](diffhunk://#diff-f9addb460e347a9f14087936cb13b28dc2b3e5ceb87aaf61d25e5f84a4d6784dL104-R94) [[4]](diffhunk://#diff-f9addb460e347a9f14087936cb13b28dc2b3e5ceb87aaf61d25e5f84a4d6784dL163-R148) [[5]](diffhunk://#diff-f9addb460e347a9f14087936cb13b28dc2b3e5ceb87aaf61d25e5f84a4d6784dL192-R172) [[6]](diffhunk://#diff-f9addb460e347a9f14087936cb13b28dc2b3e5ceb87aaf61d25e5f84a4d6784dL224-R199) [[7]](diffhunk://#diff-f9addb460e347a9f14087936cb13b28dc2b3e5ceb87aaf61d25e5f84a4d6784dL283-R253) [[8]](diffhunk://#diff-f9addb460e347a9f14087936cb13b28dc2b3e5ceb87aaf61d25e5f84a4d6784dL313-R278) [[9]](diffhunk://#diff-f9addb460e347a9f14087936cb13b28dc2b3e5ceb87aaf61d25e5f84a4d6784dL345-R305) [[10]](diffhunk://#diff-f9addb460e347a9f14087936cb13b28dc2b3e5ceb87aaf61d25e5f84a4d6784dL404-R359) [[11]](diffhunk://#diff-f9addb460e347a9f14087936cb13b28dc2b3e5ceb87aaf61d25e5f84a4d6784dL433-R383) [[12]](diffhunk://#diff-f9addb460e347a9f14087936cb13b28dc2b3e5ceb87aaf61d25e5f84a4d6784dL465-R410) [[13]](diffhunk://#diff-f9addb460e347a9f14087936cb13b28dc2b3e5ceb87aaf61d25e5f84a4d6784dL524-R464) [[14]](diffhunk://#diff-f9addb460e347a9f14087936cb13b28dc2b3e5ceb87aaf61d25e5f84a4d6784dL553-R488) [[15]](diffhunk://#diff-f9addb460e347a9f14087936cb13b28dc2b3e5ceb87aaf61d25e5f84a4d6784dL616-R546) [[16]](diffhunk://#diff-f9addb460e347a9f14087936cb13b28dc2b3e5ceb87aaf61d25e5f84a4d6784dL645-R570) [[17]](diffhunk://#diff-f9addb460e347a9f14087936cb13b28dc2b3e5ceb87aaf61d25e5f84a4d6784dL677-R597)

Other changes:

* [`pkg/bucketeer/sdk.go`](diffhunk://#diff-9658208f158246a9cfbc2c798e77e8224eaed053c42d140eb1e7237d8ed4e91cL82-L83): Removed `SourceIDGoServer` constant.
* [`pkg/bucketeer/model/register_events_request.go`](diffhunk://#diff-354b7f6da510b7db9b0ad8be542f9275a1a328eb710070fbacf53c7ef20062d5R3-R16): Added `SDKVersion` and `SourceID` to `RegisterEventsRequest` struct and introduced `NewRegisterEventsRequest` method.