### PR TITLE
chore: add metric events in the cache processors

### DIFF
--- a/pkg/bucketeer/model/metrics_event.go
+++ b/pkg/bucketeer/model/metrics_event.go
@@ -31,7 +31,12 @@ type metricsDetailEventType string
 
 type APIID int
 
+// The API IDs must match the IDs defined on the main repository
+// https://github.com/bucketeer-io/bucketeer/blob/main/proto/event/client/event.proto
 const (
-	GetEvaluation  APIID = 1
-	RegisterEvents APIID = 3
+	GetEvaluation   APIID = 1
+	RegisterEvents  APIID = 3
+	GetFeatureFlags APIID = 4
+	GetSegmentUsers APIID = 5
+	SDKGetVariation APIID = 100
 )


### PR DESCRIPTION
Part of https://github.com/bucketeer-io/bucketeer/issues/921

---

This pull request primarily includes changes to the `pkg/bucketeer/cache/processor` package in the Bucketeer service. These changes are aimed at enhancing the metrics reporting capabilities by introducing new functions to push latency metrics, size metrics, and error events. The changes also include modifications to the test files to accommodate these new functionalities.

The most important changes are:

Additions to the `processor` struct:

* [`pkg/bucketeer/cache/processor/feature_flag_processor.go`](diffhunk://#diff-39d4680964b0405085215e7c71c9dd8a26656177eace993d30e5f3e495802796R33-R35): Added three new functions to the `processor` struct: `pushLatencyMetricsEvent`, `pushSizeMetricsEvent`, and `pushErrorEvent`. These functions are designed to push latency metrics, size metrics, and error events respectively. A new `tag` field was also added to the struct.

Modifications to the `FeatureFlagProcessorConfig` struct:

* [`pkg/bucketeer/cache/processor/feature_flag_processor.go`](diffhunk://#diff-39d4680964b0405085215e7c71c9dd8a26656177eace993d30e5f3e495802796R52-R60): Added new fields to the `FeatureFlagProcessorConfig` struct that correspond to the new functions added to the `processor` struct. Also added a new `Tag` field to this struct.

Changes to the `NewFeatureFlagProcessor` function:

* [`pkg/bucketeer/cache/processor/feature_flag_processor.go`](diffhunk://#diff-39d4680964b0405085215e7c71c9dd8a26656177eace993d30e5f3e495802796R81-R83): Modified the `NewFeatureFlagProcessor` function to include the new functions and `tag` field in the returned `FeatureFlagProcessor`.

Changes to the `updateCache` method:

* [`pkg/bucketeer/cache/processor/feature_flag_processor.go`](diffhunk://#diff-39d4680964b0405085215e7c71c9dd8a26656177eace993d30e5f3e495802796R143-R151): The `updateCache` method now pushes latency metrics, size metrics, and error events using the new functions.

Changes to the test files:

* [`pkg/bucketeer/cache/processor/feature_flag_processor_test.go`](diffhunk://#diff-b2a32d9735aa23a42d7e2267ca6c7d6de5c26bb4f0a79767c251722089c63c03R32): The test files were updated to mock the new functions and to test their functionality. The `processor` struct in the test files was also modified to include these new functions. [[1]](diffhunk://#diff-b2a32d9735aa23a42d7e2267ca6c7d6de5c26bb4f0a79767c251722089c63c03R32) [[2]](diffhunk://#diff-b2a32d9735aa23a42d7e2267ca6c7d6de5c26bb4f0a79767c251722089c63c03L59-R70) [[3]](diffhunk://#diff-b2a32d9735aa23a42d7e2267ca6c7d6de5c26bb4f0a79767c251722089c63c03R84-R130) [[4]](diffhunk://#diff-b2a32d9735aa23a42d7e2267ca6c7d6de5c26bb4f0a79767c251722089c63c03L133-R140) [[5]](diffhunk://#diff-b2a32d9735aa23a42d7e2267ca6c7d6de5c26bb4f0a79767c251722089c63c03R154-R163) [[6]](diffhunk://#diff-b2a32d9735aa23a42d7e2267ca6c7d6de5c26bb4f0a79767c251722089c63c03L164-R174) [[7]](diffhunk://#diff-b2a32d9735aa23a42d7e2267ca6c7d6de5c26bb4f0a79767c251722089c63c03R188-R197) [[8]](diffhunk://#diff-b2a32d9735aa23a42d7e2267ca6c7d6de5c26bb4f0a79767c251722089c63c03L195-R208) [[9]](diffhunk://#diff-b2a32d9735aa23a42d7e2267ca6c7d6de5c26bb4f0a79767c251722089c63c03L227-R243) [[10]](diffhunk://#diff-b2a32d9735aa23a42d7e2267ca6c7d6de5c26bb4f0a79767c251722089c63c03R257-R266) [[11]](diffhunk://#diff-b2a32d9735aa23a42d7e2267ca6c7d6de5c26bb4f0a79767c251722089c63c03R278-R287) [[12]](diffhunk://#diff-b2a32d9735aa23a42d7e2267ca6c7d6de5c26bb4f0a79767c251722089c63c03R299-R308) [[13]](diffhunk://#diff-b2a32d9735aa23a42d7e2267ca6c7d6de5c26bb4f0a79767c251722089c63c03R333-L327) [[14]](diffhunk://#diff-b2a32d9735aa23a42d7e2267ca6c7d6de5c26bb4f0a79767c251722089c63c03R359-R370) [[15]](diffhunk://#diff-b2a32d9735aa23a42d7e2267ca6c7d6de5c26bb4f0a79767c251722089c63c03R392-R424)

Changes to the `segmentUserProcessor` struct:

* [`pkg/bucketeer/cache/processor/segment_user_processor.go`](diffhunk://#diff-5f737e782e43da6f44d668d86679bee6a441702872314746399f3d7e60fd7495R33-R36): Similar to the `processor` struct, the `segmentUserProcessor` struct was also updated to include the new functions and `tag` field.

Modifications to the `SegmentUserProcessorConfig` struct:

* [`pkg/bucketeer/cache/processor/segment_user_processor.go`](diffhunk://#diff-5f737e782e43da6f44d668d86679bee6a441702872314746399f3d7e60fd7495R52-R68): The `SegmentUserProcessorConfig` struct was updated to include the new functions and `tag` field.