### PR TITLE
fix: skip event generation for unauthorized and forbidden errors

### DIFF
--- a/pkg/bucketeer/event/processor.go
+++ b/pkg/bucketeer/event/processor.go
@@ -296,10 +296,11 @@ func (p *processor) pushErrorStatusCodeMetricsEvent(api model.APIID, code int, e
 		evt = model.NewRedirectionRequestErrorMetricsEvent(p.tag, api, code)
 	case code == http.StatusBadRequest:
 		evt = model.NewBadRequestErrorMetricsEvent(p.tag, api)
-	case code == http.StatusUnauthorized:
-		evt = model.NewUnauthorizedErrorMetricsEvent(p.tag, api)
-	case code == http.StatusForbidden:
-		evt = model.NewForbiddenErrorMetricsEvent(p.tag, api)
+		// We don't generate error events for unaturothized and forbidden errors
+		// because they can't be reported using an invalid API key, so we only log them.
+	case code == http.StatusUnauthorized || code == http.StatusForbidden:
+		p.loggers.Errorf("bucketeer/event: failed to request (err: %v, tag: %s, api: %d)", err, p.tag, api)
+		return
 	case code == http.StatusNotFound:
 		evt = model.NewNotFoundErrorMetricsEvent(p.tag, api)
 	case code == http.StatusMethodNotAllowed:

--- a/pkg/bucketeer/event/processor_test.go
+++ b/pkg/bucketeer/event/processor_test.go
@@ -155,6 +155,32 @@ func TestPushInternalSDKErrorMetricsEvent(t *testing.T) {
 	assert.Equal(t, model.InternalSDKErrorMetricsEventType, iecMetricsEvt.Type)
 }
 
+func TestUnauthorizedError(t *testing.T) {
+	t.Parallel()
+	p := newProcessorForTestPushEvent(t, 10)
+	p.pushErrorStatusCodeMetricsEvent(model.GetEvaluation, http.StatusUnauthorized, errors.New("StatusUnauthorized"))
+	select {
+	case evt := <-p.evtQueue.eventCh():
+		// If we receive an event, the test should fail
+		t.Errorf("Expected no event for unauthorized error, but got: %v", evt)
+	case <-time.After(time.Millisecond * 300):
+		// No event received
+	}
+}
+
+func TestStatusForbiddenError(t *testing.T) {
+	t.Parallel()
+	p := newProcessorForTestPushEvent(t, 10)
+	p.pushErrorStatusCodeMetricsEvent(model.GetEvaluation, http.StatusForbidden, errors.New("StatusForbidden"))
+	select {
+	case evt := <-p.evtQueue.eventCh():
+		// If we receive an event, the test should fail
+		t.Errorf("Expected no event for forbidden error, but got: %v", evt)
+	case <-time.After(time.Millisecond * 300):
+		// No event received
+	}
+}
+
 func TestPushErrorStatusCodeMetricsEventInternalServerError(t *testing.T) {
 	t.Parallel()
 	p := newProcessorForTestPushEvent(t, 10)

--- a/pkg/bucketeer/model/status.go
+++ b/pkg/bucketeer/model/status.go
@@ -32,36 +32,6 @@ func NewBadRequestErrorMetricsEvent(tag string, api APIID) *BadRequestErrorMetri
 	}
 }
 
-// HTTP Mapping: 401 Unauthorized
-type UnauthorizedErrorMetricsEvent struct {
-	APIID  APIID                `json:"apiId,omitempty"`
-	Labels map[string]string    `json:"labels,omitempty"`
-	Type   errorStatusEventType `json:"@type,omitempty"`
-}
-
-func NewUnauthorizedErrorMetricsEvent(tag string, api APIID) *UnauthorizedErrorMetricsEvent {
-	return &UnauthorizedErrorMetricsEvent{
-		APIID:  api,
-		Labels: map[string]string{"tag": tag},
-		Type:   UnauthorizedErrorMetricsEventType,
-	}
-}
-
-// HTTP Mapping: 403 Forbidden
-type ForbiddenErrorMetricsEvent struct {
-	APIID  APIID                `json:"apiId,omitempty"`
-	Labels map[string]string    `json:"labels,omitempty"`
-	Type   errorStatusEventType `json:"@type,omitempty"`
-}
-
-func NewForbiddenErrorMetricsEvent(tag string, api APIID) *ForbiddenErrorMetricsEvent {
-	return &ForbiddenErrorMetricsEvent{
-		APIID:  api,
-		Labels: map[string]string{"tag": tag},
-		Type:   ForbiddenErrorMetricsEventType,
-	}
-}
-
 // HTTP Mapping: 404 Not Found
 type NotFoundErrorMetricsEvent struct {
 	APIID  APIID                `json:"apiId,omitempty"`

--- a/pkg/bucketeer/model/status_test.go
+++ b/pkg/bucketeer/model/status_test.go
@@ -15,22 +15,6 @@ func TestNewBadRequestErrorMetricsEvent(t *testing.T) {
 	assert.Equal(t, BadRequestErrorMetricsEventType, e.Type)
 }
 
-func TestNewUnauthorizedErrorMetricsEvent(t *testing.T) {
-	t.Parallel()
-	e := NewUnauthorizedErrorMetricsEvent(tag, GetEvaluation)
-	assert.IsType(t, &UnauthorizedErrorMetricsEvent{}, e)
-	assert.Equal(t, tag, e.Labels["tag"])
-	assert.Equal(t, UnauthorizedErrorMetricsEventType, e.Type)
-}
-
-func TestNewForbiddenErrorMetricsEvent(t *testing.T) {
-	t.Parallel()
-	e := NewForbiddenErrorMetricsEvent(tag, GetEvaluation)
-	assert.IsType(t, &ForbiddenErrorMetricsEvent{}, e)
-	assert.Equal(t, tag, e.Labels["tag"])
-	assert.Equal(t, ForbiddenErrorMetricsEventType, e.Type)
-}
-
 func TestNewNotFoundErrorMetricsEvent(t *testing.T) {
 	t.Parallel()
 	e := NewNotFoundErrorMetricsEvent(tag, GetEvaluation)


### PR DESCRIPTION
Part of https://github.com/bucketeer-io/bucketeer/issues/1284