### PR TITLE
test: add variationID for sdk e2e

### DIFF
--- a/test/e2e/api_test.go
+++ b/test/e2e/api_test.go
@@ -116,7 +116,7 @@ func TestRegisterEvents(t *testing.T) {
 		Tag:            tag,
 		FeatureID:      featureID,
 		FeatureVersion: 0,
-		VariationID:    "",
+		VariationID:    variationID,
 		User:           user,
 		Reason:         &model.Reason{Type: model.ReasonClient},
 		Type:           model.EvaluationEventType,

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -13,6 +13,7 @@ const (
 	featureID           = "feature-go-server-e2e-string"
 	featureIDVariation1 = "value-1"
 	featureIDVariation2 = "value-2"
+	variationID         = "variation-id"
 	goalID              = "goal-go-server-e2e-1"
 
 	// Sdk Test


### PR DESCRIPTION
We added validations for sdk(https://github.com/bucketeer-io/bucketeer/pull/1650).
So we should fix e2e test data in go sdk.