### PR TITLE
feat: add scheme configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,4 +46,4 @@ coverage:
 .PHONY: e2e
 e2e:
 	go test -v -race ./test/e2e/... \
-		-args -api-key=${API_KEY} -api-key-server=${API_KEY_SERVER} -host=${HOST} -port=${PORT}
+		-args -api-key=${API_KEY} -api-key-server=${API_KEY_SERVER} -host=${HOST} -port=${PORT} -scheme=${SCHEME}

--- a/pkg/bucketeer/option.go
+++ b/pkg/bucketeer/option.go
@@ -14,6 +14,7 @@ type options struct {
 	cachePollingInterval  time.Duration
 	tag                   string
 	apiKey                string
+	scheme                string
 	host                  string
 	port                  int
 	eventQueueCapacity    int
@@ -29,6 +30,7 @@ var defaultOptions = options{
 	cachePollingInterval:  1 * time.Minute,
 	tag:                   "",
 	apiKey:                "",
+	scheme:                "https",
 	host:                  "",
 	port:                  443,
 	eventQueueCapacity:    100_000,
@@ -69,6 +71,13 @@ func WithTag(tag string) Option {
 func WithAPIKey(apiKey string) Option {
 	return func(opts *options) {
 		opts.apiKey = apiKey
+	}
+}
+
+// WithScheme sets scheme to use Bucketeer service. (Default: "https")
+func WithScheme(scheme string) Option {
+	return func(opts *options) {
+		opts.scheme = scheme
 	}
 }
 

--- a/pkg/bucketeer/option_test.go
+++ b/pkg/bucketeer/option_test.go
@@ -15,6 +15,7 @@ func TestWithOptions(t *testing.T) {
 	cachePollingInterval := 30 * time.Second
 	tag := "go-server"
 	apiKey := "apiKey"
+	scheme := "http"
 	host := "host"
 	port := 8443
 	eventQueueCapacity := 100
@@ -29,6 +30,7 @@ func TestWithOptions(t *testing.T) {
 		WithCachePollingInterval(cachePollingInterval),
 		WithTag(tag),
 		WithAPIKey(apiKey),
+		WithScheme(scheme),
 		WithHost(host),
 		WithPort(port),
 		WithEventQueueCapacity(eventQueueCapacity),
@@ -47,6 +49,7 @@ func TestWithOptions(t *testing.T) {
 	assert.Equal(t, cachePollingInterval, dopts.cachePollingInterval)
 	assert.Equal(t, tag, dopts.tag)
 	assert.Equal(t, apiKey, dopts.apiKey)
+	assert.Equal(t, scheme, dopts.scheme)
 	assert.Equal(t, host, dopts.host)
 	assert.Equal(t, port, dopts.port)
 	assert.Equal(t, eventQueueCapacity, dopts.eventQueueCapacity)

--- a/pkg/bucketeer/sdk.go
+++ b/pkg/bucketeer/sdk.go
@@ -147,7 +147,11 @@ func NewSDK(ctx context.Context, opts ...Option) (SDK, error) {
 		ErrorLogger:    dopts.errorLogger,
 	}
 	loggers := log.NewLoggers(loggerConf)
-	client, err := api.NewClient(&api.ClientConfig{APIKey: dopts.apiKey, Host: dopts.host})
+	client, err := api.NewClient(&api.ClientConfig{
+		APIKey: dopts.apiKey,
+		Scheme: dopts.scheme,
+		Host:   dopts.host,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("bucketeer: failed to new api client: %w", err)
 	}

--- a/test/e2e/api_test.go
+++ b/test/e2e/api_test.go
@@ -222,6 +222,7 @@ func newAPIClient(t *testing.T, apiKey string) api.Client {
 	conf := &api.ClientConfig{
 		APIKey: apiKey,
 		Host:   *host,
+		Scheme: *scheme,
 	}
 	client, err := api.NewClient(conf)
 	assert.NoError(t, err)

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -49,5 +49,6 @@ var (
 	apiKey       = flag.String("api-key", "", "API key for the Bucketeer service")
 	apiKeyServer = flag.String("api-key-server", "", "API key for Server SDK")
 	host         = flag.String("host", "", "Host name of the Bucketeer service, e.g. api-dev.bucketeer.jp")
+	scheme       = flag.String("scheme", "https", "Scheme of the Bucketeer service, e.g. https")
 	port         = flag.Int("port", 443, "Port number of the Bucketeer service, e.g. 443")
 )

--- a/test/e2e/sdk_local_evaluation_test.go
+++ b/test/e2e/sdk_local_evaluation_test.go
@@ -278,6 +278,7 @@ func newLocalSDK(t *testing.T, ctx context.Context) bucketeer.SDK {
 		bucketeer.WithTag(tag),
 		bucketeer.WithAPIKey(*apiKeyServer),
 		bucketeer.WithHost(*host),
+		bucketeer.WithScheme(*scheme),
 		bucketeer.WithPort(*port),
 		bucketeer.WithEventQueueCapacity(100),
 		bucketeer.WithNumEventFlushWorkers(3),

--- a/test/e2e/sdk_test.go
+++ b/test/e2e/sdk_test.go
@@ -597,6 +597,7 @@ func newSDK(t *testing.T, ctx context.Context) bucketeer.SDK {
 		bucketeer.WithTag(tag),
 		bucketeer.WithAPIKey(*apiKey),
 		bucketeer.WithHost(*host),
+		bucketeer.WithScheme(*scheme),
 		bucketeer.WithPort(*port),
 		bucketeer.WithEventQueueCapacity(100),
 		bucketeer.WithNumEventFlushWorkers(3),


### PR DESCRIPTION
Currently, go-server-sdk doesn't provide way to handle scheme and it's hard to debug on local since the all request send to as a HTTPS.
By making client's scheme configurable, we can use client not only hosting environment but also local one.