### PR TITLE
test: fix flaky TestGetTargetFeatures

### DIFF
--- a/pkg/bucketeer/evaluator/evaluator_test.go
+++ b/pkg/bucketeer/evaluator/evaluator_test.go
@@ -378,6 +378,8 @@ func TestGetTargetFeatures(t *testing.T) {
 			setup: func(e *evaluator) {
 				// The `ft4` is the prerequisite flag configured in the `ft3`
 				e.featuresCache.(*mock.MockFeaturesCache).EXPECT().Get(ft4.Id).Return(nil, internalErr)
+				// The `ft5` is referenced in the `ft3` clauses
+				e.featuresCache.(*mock.MockFeaturesCache).EXPECT().Get(ft5.Id).Return(ft5, nil)
 			},
 			feature:     ft3, // Contains the `ft4` as prerequite
 			expected:    nil,
@@ -407,7 +409,7 @@ func TestGetTargetFeatures(t *testing.T) {
 			evaluator := newEvaluator(t, "tag", controller)
 			p.setup(evaluator)
 			features, err := evaluator.getTargetFeatures(p.feature)
-			assert.Equal(t, p.expected, features)
+			assert.ElementsMatch(t, p.expected, features)
 			assert.Equal(t, p.expectedErr, err)
 		})
 	}


### PR DESCRIPTION
TestGetTargetFeatures fails sometimes because of:
1. Unexpected call `mock.MockFeaturesCache.Get([feature-id-5])`
```
=== NAME  TestGetTargetFeatures
    evaluator.go:127: Unexpected call to *mock.MockFeaturesCache.Get([feature-id-5]) at /home/runner/work/go-server-sdk/go-server-sdk/pkg/bucketeer/evaluator/evaluator.go:127 
 〜
```
2.  The order mismatch of slice elements
```
=== NAME  TestGetTargetFeatures/success
    evaluator_test.go:410: 
        	Error Trace:	/home/runner/work/go-server-sdk/go-server-sdk/pkg/bucketeer/evaluator/evaluator_test.go:410
        	Error:      	Not equal: 
        	            	expected: []*feature.Feature{(*feature.Feature)(0x14be680), (*feature.Feature)(0x14be400), (*feature.Feature)(0x14be540)}
        	            	actual  : []*feature.Feature{(*feature.Feature)(0x14be680), (*feature.Feature)(0x14be540), (*feature.Feature)(0x14be400)}
〜
```

So I fixed both.