### PR TITLE
feat: add SDK version support to options

### DIFF
--- a/pkg/bucketeer/cache/processor/feature_flag_processor.go
+++ b/pkg/bucketeer/cache/processor/feature_flag_processor.go
@@ -35,6 +35,7 @@ type processor struct {
 	pushSizeMetricsEvent    func(sizeByte int, api model.APIID)
 	pushErrorEvent          func(err error, api model.APIID)
 	tag                     string
+	sdkVersion              string
 	closeCh                 chan struct{}
 	loggers                 *log.Loggers
 }
@@ -140,6 +141,7 @@ func (p *processor) updateCache() error {
 	req := model.NewGetFeatureFlagsRequest(
 		p.tag,
 		ftsID,
+		p.sdkVersion,
 		requestedAt,
 	)
 	// Get the latest cache from the server

--- a/pkg/bucketeer/cache/processor/feature_flag_processor_test.go
+++ b/pkg/bucketeer/cache/processor/feature_flag_processor_test.go
@@ -31,6 +31,10 @@ import (
 	mockevt "github.com/bucketeer-io/go-server-sdk/test/mock/event"
 )
 
+const (
+	sdkVersion = "1.5.5"
+)
+
 func TestPollingInterval(t *testing.T) {
 	t.Parallel()
 	mockController := gomock.NewController(t)
@@ -114,7 +118,7 @@ func TestUpdateCache(t *testing.T) {
 				p.cache.(*mockcache.MockCache).EXPECT().Get(featureFlagsIDKey).Return("", nil)
 				p.cache.(*mockcache.MockCache).EXPECT().Get(featureFlagsRequestedAtKey).Return(int64(0), nil)
 
-				req := model.NewGetFeatureFlagsRequest(tag, "", int64(0))
+				req := model.NewGetFeatureFlagsRequest(tag, "", sdkVersion, int64(0))
 				p.apiClient.(*mockapi.MockClient).EXPECT().GetFeatureFlags(req).Return(
 					nil,
 					0,
@@ -136,7 +140,7 @@ func TestUpdateCache(t *testing.T) {
 				// Call in the processor cache
 				p.cache.(*mockcache.MockCache).EXPECT().Put(featureFlagsIDKey, "feature-flags-id-2", cacheTTL).Return(internalErr)
 
-				req := model.NewGetFeatureFlagsRequest(tag, "feature-flags-id-1", int64(10))
+				req := model.NewGetFeatureFlagsRequest(tag, "feature-flags-id-1", sdkVersion, int64(10))
 				p.apiClient.(*mockapi.MockClient).EXPECT().GetFeatureFlags(req).Return(
 					&model.GetFeatureFlagsResponse{
 						FeatureFlagsID:         "feature-flags-id-2",
@@ -171,7 +175,7 @@ func TestUpdateCache(t *testing.T) {
 				p.cache.(*mockcache.MockCache).EXPECT().Get(featureFlagsIDKey).Return("feature-flags-id-1", nil)
 				p.cache.(*mockcache.MockCache).EXPECT().Get(featureFlagsRequestedAtKey).Return(int64(10), nil)
 
-				req := model.NewGetFeatureFlagsRequest(tag, "feature-flags-id-1", int64(10))
+				req := model.NewGetFeatureFlagsRequest(tag, "feature-flags-id-1", sdkVersion, int64(10))
 				p.apiClient.(*mockapi.MockClient).EXPECT().GetFeatureFlags(req).Return(
 					&model.GetFeatureFlagsResponse{
 						FeatureFlagsID:         "feature-flags-id-2",
@@ -210,7 +214,7 @@ func TestUpdateCache(t *testing.T) {
 				p.cache.(*mockcache.MockCache).EXPECT().Get(featureFlagsIDKey).Return("feature-flags-id-1", nil)
 				p.cache.(*mockcache.MockCache).EXPECT().Get(featureFlagsRequestedAtKey).Return(int64(10), nil)
 
-				req := model.NewGetFeatureFlagsRequest(tag, "feature-flags-id-1", int64(10))
+				req := model.NewGetFeatureFlagsRequest(tag, "feature-flags-id-1", sdkVersion, int64(10))
 				p.apiClient.(*mockapi.MockClient).EXPECT().GetFeatureFlags(req).Return(
 					&model.GetFeatureFlagsResponse{
 						FeatureFlagsID:         "feature-flags-id-2",
@@ -248,7 +252,7 @@ func TestUpdateCache(t *testing.T) {
 				p.cache.(*mockcache.MockCache).EXPECT().Get(featureFlagsIDKey).Return("feature-flags-id-1", nil)
 				p.cache.(*mockcache.MockCache).EXPECT().Get(featureFlagsRequestedAtKey).Return(int64(10), nil)
 
-				req := model.NewGetFeatureFlagsRequest(tag, "feature-flags-id-1", int64(10))
+				req := model.NewGetFeatureFlagsRequest(tag, "feature-flags-id-1", sdkVersion, int64(10))
 				p.apiClient.(*mockapi.MockClient).EXPECT().GetFeatureFlags(req).Return(
 					&model.GetFeatureFlagsResponse{
 						FeatureFlagsID:         "feature-flags-id-2",
@@ -288,7 +292,7 @@ func TestUpdateCache(t *testing.T) {
 				p.cache.(*mockcache.MockCache).EXPECT().Put(featureFlagsIDKey, "", cacheTTL).Return(nil)
 				p.cache.(*mockcache.MockCache).EXPECT().Put(featureFlagsRequestedAtKey, int64(0), cacheTTL).Return(nil)
 
-				req := model.NewGetFeatureFlagsRequest(tag, "", int64(10))
+				req := model.NewGetFeatureFlagsRequest(tag, "", sdkVersion, int64(10))
 				p.apiClient.(*mockapi.MockClient).EXPECT().GetFeatureFlags(req).Return(
 					&model.GetFeatureFlagsResponse{},
 					1,
@@ -309,7 +313,7 @@ func TestUpdateCache(t *testing.T) {
 				p.cache.(*mockcache.MockCache).EXPECT().Put(featureFlagsIDKey, "", cacheTTL).Return(nil)
 				p.cache.(*mockcache.MockCache).EXPECT().Put(featureFlagsRequestedAtKey, int64(0), cacheTTL).Return(nil)
 
-				req := model.NewGetFeatureFlagsRequest(tag, "feature-flags-id-1", int64(0))
+				req := model.NewGetFeatureFlagsRequest(tag, "feature-flags-id-1", sdkVersion, int64(0))
 				p.apiClient.(*mockapi.MockClient).EXPECT().GetFeatureFlags(req).Return(
 					&model.GetFeatureFlagsResponse{},
 					1,
@@ -340,7 +344,7 @@ func TestUpdateCache(t *testing.T) {
 				p.cache.(*mockcache.MockCache).EXPECT().Put(featureFlagsIDKey, "feature-flags-id-2", cacheTTL).Return(nil)
 				p.cache.(*mockcache.MockCache).EXPECT().Put(featureFlagsRequestedAtKey, int64(20), cacheTTL).Return(nil)
 
-				req := model.NewGetFeatureFlagsRequest(tag, "feature-flags-id-1", int64(10))
+				req := model.NewGetFeatureFlagsRequest(tag, "feature-flags-id-1", sdkVersion, int64(10))
 				p.apiClient.(*mockapi.MockClient).EXPECT().GetFeatureFlags(req).Return(
 					&model.GetFeatureFlagsResponse{
 						FeatureFlagsID:         "feature-flags-id-2",
@@ -366,7 +370,7 @@ func TestUpdateCache(t *testing.T) {
 				p.cache.(*mockcache.MockCache).EXPECT().Get(featureFlagsIDKey).Return("feature-flags-id-1", nil)
 				p.cache.(*mockcache.MockCache).EXPECT().Get(featureFlagsRequestedAtKey).Return(int64(10), nil)
 
-				req := model.NewGetFeatureFlagsRequest(tag, "feature-flags-id-1", int64(10))
+				req := model.NewGetFeatureFlagsRequest(tag, "feature-flags-id-1", sdkVersion, int64(10))
 				p.apiClient.(*mockapi.MockClient).EXPECT().GetFeatureFlags(req).Return(
 					&model.GetFeatureFlagsResponse{
 						FeatureFlagsID:         "feature-flags-id-2",
@@ -442,6 +446,7 @@ func newMockFeatureFlagProcessor(
 			cache:                   cacheInMemory,
 			featureFlagsCache:       featureFlagsCache,
 			tag:                     tag,
+			sdkVersion:              sdkVersion,
 			closeCh:                 make(chan struct{}),
 			pollingInterval:         pollingInterval,
 			loggers:                 log.NewLoggers(loggerConf),

--- a/pkg/bucketeer/event/processor_test.go
+++ b/pkg/bucketeer/event/processor_test.go
@@ -27,11 +27,6 @@ const (
 	processorGoalID      = "goal-id"
 )
 
-type registerEventsResponseError struct {
-	Retriable bool   `json:"retriable,omitempty"`
-	Message   string `json:"message,omitempty"`
-}
-
 func TestPushEvaluationEvent(t *testing.T) {
 	t.Parallel()
 	p := newProcessorForTestPushEvent(t, 10)
@@ -39,7 +34,7 @@ func TestPushEvaluationEvent(t *testing.T) {
 	evaluation := newEvaluation(t, processorFeatureID, processorVariationID)
 	p.PushEvaluationEvent(user, evaluation)
 	evt := <-p.evtQueue.eventCh()
-	e := &model.EvaluationEvent{}
+	e := model.NewEvaluationEvent(p.tag, processorFeatureID, "", version.SDKVersion, 0, user, &model.Reason{Type: model.ReasonClient})
 	err := json.Unmarshal(evt.Event, e)
 	assert.NoError(t, err)
 	assert.Equal(t, p.tag, e.Tag)
@@ -59,7 +54,7 @@ func TestPushDefaultEvaluationEvent(t *testing.T) {
 	user := newUser(t, processorUserID)
 	p.PushDefaultEvaluationEvent(user, processorFeatureID)
 	evt := <-p.evtQueue.eventCh()
-	e := &model.EvaluationEvent{}
+	e := model.NewEvaluationEvent(p.tag, processorFeatureID, "", version.SDKVersion, 0, user, &model.Reason{Type: model.ReasonClient})
 	err := json.Unmarshal(evt.Event, e)
 	assert.NoError(t, err)
 	assert.Equal(t, p.tag, e.Tag)
@@ -79,7 +74,7 @@ func TestPushGoalEvent(t *testing.T) {
 	user := newUser(t, processorUserID)
 	p.PushGoalEvent(user, processorGoalID, 1.1)
 	evt := <-p.evtQueue.eventCh()
-	e := &model.GoalEvent{}
+	e := model.NewGoalEvent(p.tag, processorGoalID, version.SDKVersion, 1.1, user)
 	err := json.Unmarshal(evt.Event, e)
 	assert.NoError(t, err)
 	assert.Equal(t, p.tag, e.Tag)

--- a/pkg/bucketeer/model/evaluation_event.go
+++ b/pkg/bucketeer/model/evaluation_event.go
@@ -4,8 +4,6 @@ import (
 	"time"
 
 	"github.com/bucketeer-io/go-server-sdk/pkg/bucketeer/user"
-
-	"github.com/bucketeer-io/go-server-sdk/pkg/bucketeer/version"
 )
 
 type EvaluationEvent struct {
@@ -23,7 +21,7 @@ type EvaluationEvent struct {
 }
 
 func NewEvaluationEvent(
-	tag, featureID, variationID string,
+	tag, featureID, variationID, sdkVersion string,
 	featureVersion int32,
 	user *user.User,
 	reason *Reason,
@@ -37,7 +35,7 @@ func NewEvaluationEvent(
 		User:           user,
 		Reason:         reason,
 		SourceID:       SourceIDGoServer,
-		SDKVersion:     version.SDKVersion,
+		SDKVersion:     sdkVersion,
 		Metadata:       map[string]string{},
 		Type:           EvaluationEventType,
 	}

--- a/pkg/bucketeer/model/evaluation_event_test.go
+++ b/pkg/bucketeer/model/evaluation_event_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestNewEvaluationEvent(t *testing.T) {
 	t.Parallel()
-	e := NewEvaluationEvent(tag, featureID, variationID, featureVersion, newUser(t, id), &Reason{Type: ReasonClient})
+	e := NewEvaluationEvent(tag, featureID, variationID, version.SDKVersion, featureVersion, newUser(t, id), &Reason{Type: ReasonClient})
 	assert.IsType(t, &EvaluationEvent{}, e)
 	assert.Equal(t, tag, e.Tag)
 	assert.Equal(t, EvaluationEventType, e.Type)

--- a/pkg/bucketeer/model/get_evaluation_request.go
+++ b/pkg/bucketeer/model/get_evaluation_request.go
@@ -2,7 +2,6 @@ package model
 
 import (
 	"github.com/bucketeer-io/go-server-sdk/pkg/bucketeer/user"
-	"github.com/bucketeer-io/go-server-sdk/pkg/bucketeer/version"
 )
 
 type GetEvaluationRequest struct {
@@ -13,12 +12,15 @@ type GetEvaluationRequest struct {
 	SDKVersion string       `json:"sdkVersion,omitempty"`
 }
 
-func NewGetEvaluationRequest(tag, featureID string, user *user.User) *GetEvaluationRequest {
+func NewGetEvaluationRequest(
+	tag, featureID, sdkVersion string,
+	user *user.User,
+) *GetEvaluationRequest {
 	return &GetEvaluationRequest{
 		Tag:        tag,
 		User:       user,
 		FeatureID:  featureID,
 		SourceID:   SourceIDGoServer,
-		SDKVersion: version.SDKVersion,
+		SDKVersion: sdkVersion,
 	}
 }

--- a/pkg/bucketeer/model/get_evaluation_request_test.go
+++ b/pkg/bucketeer/model/get_evaluation_request_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestNewGetEvaluationRequest(t *testing.T) {
 	t.Parallel()
-	e := NewGetEvaluationRequest(tag, featureID, newUser(t, id))
+	e := NewGetEvaluationRequest(tag, featureID, version.SDKVersion, newUser(t, id))
 	assert.IsType(t, &GetEvaluationRequest{}, e)
 	assert.Equal(t, tag, e.Tag)
 	assert.Equal(t, SourceIDGoServer, e.SourceID)

--- a/pkg/bucketeer/model/get_feature_flags_request.go
+++ b/pkg/bucketeer/model/get_feature_flags_request.go
@@ -1,9 +1,5 @@
 package model
 
-import (
-	"github.com/bucketeer-io/go-server-sdk/pkg/bucketeer/version"
-)
-
 type GetFeatureFlagsRequest struct {
 	Tag            string       `json:"tag"`
 	FeatureFlagsID string       `json:"featureFlagsId"`
@@ -12,12 +8,15 @@ type GetFeatureFlagsRequest struct {
 	SDKVersion     string       `json:"sdkVersion"`
 }
 
-func NewGetFeatureFlagsRequest(tag, featureFlagsID string, requestedAt int64) *GetFeatureFlagsRequest {
+func NewGetFeatureFlagsRequest(
+	tag, featureFlagsID, sdkVersion string,
+	requestedAt int64,
+) *GetFeatureFlagsRequest {
 	return &GetFeatureFlagsRequest{
 		Tag:            tag,
 		FeatureFlagsID: featureFlagsID,
 		RequestedAt:    requestedAt,
 		SourceID:       SourceIDGoServer,
-		SDKVersion:     version.SDKVersion,
+		SDKVersion:     sdkVersion,
 	}
 }

--- a/pkg/bucketeer/model/get_feature_flags_request_test.go
+++ b/pkg/bucketeer/model/get_feature_flags_request_test.go
@@ -12,7 +12,8 @@ func TestNewGetFeatureFlagsRequest(t *testing.T) {
 	t.Parallel()
 	featureFlagsID := "fid-1"
 	requestedAt := int64(1)
-	e := NewGetFeatureFlagsRequest(tag, featureFlagsID, requestedAt)
+	sdkVersion := version.SDKVersion
+	e := NewGetFeatureFlagsRequest(tag, featureFlagsID, sdkVersion, requestedAt)
 	assert.IsType(t, &GetFeatureFlagsRequest{}, e)
 	assert.Equal(t, tag, e.Tag)
 	assert.Equal(t, featureFlagsID, e.FeatureFlagsID)

--- a/pkg/bucketeer/model/goal_event.go
+++ b/pkg/bucketeer/model/goal_event.go
@@ -4,8 +4,6 @@ import (
 	"time"
 
 	"github.com/bucketeer-io/go-server-sdk/pkg/bucketeer/user"
-
-	"github.com/bucketeer-io/go-server-sdk/pkg/bucketeer/version"
 )
 
 type GoalEvent struct {
@@ -21,7 +19,11 @@ type GoalEvent struct {
 	Type       EventType         `json:"@type,omitempty"`
 }
 
-func NewGoalEvent(tag, goalID string, value float64, user *user.User) *GoalEvent {
+func NewGoalEvent(
+	tag, goalID, sdkVersion string,
+	value float64,
+	user *user.User,
+) *GoalEvent {
 	return &GoalEvent{
 		Tag:        tag,
 		Timestamp:  time.Now().Unix(),
@@ -30,7 +32,7 @@ func NewGoalEvent(tag, goalID string, value float64, user *user.User) *GoalEvent
 		Value:      value,
 		User:       user,
 		SourceID:   SourceIDGoServer,
-		SDKVersion: version.SDKVersion,
+		SDKVersion: sdkVersion,
 		Metadata:   map[string]string{},
 		Type:       GoalEventType,
 	}

--- a/pkg/bucketeer/model/goal_event_test.go
+++ b/pkg/bucketeer/model/goal_event_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestNewGoalEvent(t *testing.T) {
 	t.Parallel()
-	e := NewGoalEvent(tag, goalID, 0.2, newUser(t, id))
+	e := NewGoalEvent(tag, goalID, version.SDKVersion, 0.2, newUser(t, id))
 	assert.IsType(t, &GoalEvent{}, e)
 	assert.Equal(t, tag, e.Tag)
 	assert.Equal(t, GoalEventType, e.Type)

--- a/pkg/bucketeer/model/metrics_event.go
+++ b/pkg/bucketeer/model/metrics_event.go
@@ -3,8 +3,6 @@ package model
 import (
 	"encoding/json"
 	"time"
-
-	"github.com/bucketeer-io/go-server-sdk/pkg/bucketeer/version"
 )
 
 type MetricsEvent struct {
@@ -16,12 +14,15 @@ type MetricsEvent struct {
 	Type       EventType         `json:"@type,omitempty"`
 }
 
-func NewMetricsEvent(encoded json.RawMessage) *MetricsEvent {
+func NewMetricsEvent(
+	encoded json.RawMessage,
+	sdkVersion string,
+) *MetricsEvent {
 	return &MetricsEvent{
 		Timestamp:  time.Now().Unix(),
 		Event:      encoded,
 		SourceID:   SourceIDGoServer,
-		SDKVersion: version.SDKVersion,
+		SDKVersion: sdkVersion,
 		Metadata:   map[string]string{},
 		Type:       MetricsEventType,
 	}

--- a/pkg/bucketeer/model/metrics_event_test.go
+++ b/pkg/bucketeer/model/metrics_event_test.go
@@ -12,7 +12,7 @@ import (
 func TestNewMetricsEvent(t *testing.T) {
 	t.Parallel()
 	json := json.RawMessage{}
-	e := NewMetricsEvent(json)
+	e := NewMetricsEvent(json, version.SDKVersion)
 	assert.IsType(t, &MetricsEvent{}, e)
 	assert.Equal(t, MetricsEventType, e.Type)
 	assert.Equal(t, e.SourceID, SourceIDGoServer)

--- a/pkg/bucketeer/option.go
+++ b/pkg/bucketeer/option.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/bucketeer-io/go-server-sdk/pkg/bucketeer/log"
+	"github.com/bucketeer-io/go-server-sdk/pkg/bucketeer/version"
 )
 
 // Option is the functional options type (Functional Options Pattern) to set sdk options.
@@ -18,6 +19,7 @@ type options struct {
 	scheme                string
 	host                  string
 	port                  int
+	sdkVersion            string
 	eventQueueCapacity    int
 	numEventFlushWorkers  int
 	eventFlushInterval    time.Duration
@@ -35,6 +37,7 @@ var defaultOptions = options{
 	scheme:                "https",
 	host:                  "",
 	port:                  443,
+	sdkVersion:            version.SDKVersion,
 	eventQueueCapacity:    100_000,
 	numEventFlushWorkers:  50,
 	eventFlushInterval:    1 * time.Minute,
@@ -106,6 +109,13 @@ func WithHost(host string) Option {
 func WithPort(port int) Option {
 	return func(opts *options) {
 		opts.port = port
+	}
+}
+
+// WithSDKVersion sets the SDK version. (Default: version.SDKVersion)
+func WithSDKVersion(sdkVersion string) Option {
+	return func(opts *options) {
+		opts.sdkVersion = sdkVersion
 	}
 }
 

--- a/pkg/bucketeer/sdk.go
+++ b/pkg/bucketeer/sdk.go
@@ -127,6 +127,7 @@ var (
 type sdk struct {
 	enableLocalEvaluation     bool
 	tag                       string
+	version                   string
 	apiClient                 api.Client
 	eventProcessor            event.Processor
 	featureFlagCacheProcessor cacheprocessor.FeatureFlagProcessor
@@ -169,6 +170,7 @@ func NewSDK(ctx context.Context, opts ...Option) (SDK, error) {
 		APIClient:       client,
 		Loggers:         loggers,
 		Tag:             dopts.tag,
+		SDKVersion:      dopts.sdkVersion,
 	}
 	processor := event.NewProcessor(ctx, processorConf)
 	if !dopts.enableLocalEvaluation {
@@ -176,6 +178,7 @@ func NewSDK(ctx context.Context, opts ...Option) (SDK, error) {
 		return &sdk{
 			enableLocalEvaluation: dopts.enableLocalEvaluation,
 			tag:                   dopts.tag,
+			version:               dopts.sdkVersion,
 			apiClient:             client,
 			eventProcessor:        processor,
 			loggers:               loggers,
@@ -206,6 +209,7 @@ func NewSDK(ctx context.Context, opts ...Option) (SDK, error) {
 	return &sdk{
 		enableLocalEvaluation:     dopts.enableLocalEvaluation,
 		tag:                       dopts.tag,
+		version:                   dopts.sdkVersion,
 		apiClient:                 client,
 		eventProcessor:            processor,
 		featureFlagCacheProcessor: fcp,
@@ -504,7 +508,7 @@ func (s *sdk) getEvaluationRemotely(
 ) (*model.Evaluation, error) {
 	reqStart := time.Now()
 	res, size, err := s.apiClient.GetEvaluation(model.NewGetEvaluationRequest(
-		s.tag, featureID,
+		s.tag, featureID, s.version,
 		user,
 	))
 	if err != nil {

--- a/pkg/bucketeer/sdk_test.go
+++ b/pkg/bucketeer/sdk_test.go
@@ -20,6 +20,7 @@ import (
 
 const (
 	sdkTag       = "go-server"
+	sdkVersion   = "1.5.5"
 	sdkUserID    = "user-id"
 	sdkFeatureID = "feature-id"
 	sdkGoalID    = "goal-id"
@@ -41,7 +42,7 @@ func TestBoolVariation(t *testing.T) {
 			desc: "return default value when failed to get evaluation",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
 				err := api.NewErrStatus(http.StatusInternalServerError)
-				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, sdkVersion, user)
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(
 					nil,
 					100, err,
@@ -63,7 +64,7 @@ func TestBoolVariation(t *testing.T) {
 		{
 			desc: "return default value when faled to parse variation",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
-				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, sdkVersion, user)
 				res := newGetEvaluationResponse(t, featureID, "invalid")
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, 100, nil)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushLatencyMetricsEvent(
@@ -87,7 +88,7 @@ func TestBoolVariation(t *testing.T) {
 		{
 			desc: "success",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
-				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, sdkVersion, user)
 				res := newGetEvaluationResponse(t, featureID, "true")
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, 100, nil)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushLatencyMetricsEvent(
@@ -138,7 +139,7 @@ func TestBoolVariationDetails(t *testing.T) {
 			desc: "return default value when failed to get evaluation",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
 				err := api.NewErrStatus(http.StatusInternalServerError)
-				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, sdkVersion, user)
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(
 					nil,
 					100, err,
@@ -168,7 +169,7 @@ func TestBoolVariationDetails(t *testing.T) {
 		{
 			desc: "return default value when filed to parse variation",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
-				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, sdkVersion, user)
 				res := newGetEvaluationResponse(t, featureID, "invalid")
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, 100, nil)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushLatencyMetricsEvent(
@@ -200,7 +201,7 @@ func TestBoolVariationDetails(t *testing.T) {
 		{
 			desc: "success",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
-				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, sdkVersion, user)
 				res := newGetEvaluationResponse(t, featureID, "true")
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, 100, nil)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushLatencyMetricsEvent(
@@ -259,7 +260,7 @@ func TestIntVariation(t *testing.T) {
 			desc: "return default value when failed to get evaluation",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
 				err := api.NewErrStatus(http.StatusInternalServerError)
-				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, sdkVersion, user)
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(
 					nil,
 					100, err,
@@ -281,7 +282,7 @@ func TestIntVariation(t *testing.T) {
 		{
 			desc: "return default value when failed to parse variation",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
-				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, sdkVersion, user)
 				res := newGetEvaluationResponse(t, featureID, "invalid")
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, 10, nil)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushLatencyMetricsEvent(
@@ -305,7 +306,7 @@ func TestIntVariation(t *testing.T) {
 		{
 			desc: "success",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
-				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, sdkVersion, user)
 				res := newGetEvaluationResponse(t, featureID, "2")
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, 20, nil)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushLatencyMetricsEvent(
@@ -329,7 +330,7 @@ func TestIntVariation(t *testing.T) {
 		{
 			desc: "success: value is float",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
-				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, sdkVersion, user)
 				res := newGetEvaluationResponse(t, featureID, "2.2")
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, 20, nil)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushLatencyMetricsEvent(
@@ -380,7 +381,7 @@ func TestIntVariationDetails(t *testing.T) {
 			desc: "return default value when failed to get evaluation",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
 				err := api.NewErrStatus(http.StatusInternalServerError)
-				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, sdkVersion, user)
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(
 					nil,
 					100, err,
@@ -410,7 +411,7 @@ func TestIntVariationDetails(t *testing.T) {
 		{
 			desc: "return default value when failed to parse variation",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
-				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, sdkVersion, user)
 				res := newGetEvaluationResponse(t, featureID, "invalid")
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, 10, nil)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushLatencyMetricsEvent(
@@ -442,7 +443,7 @@ func TestIntVariationDetails(t *testing.T) {
 		{
 			desc: "success",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
-				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, sdkVersion, user)
 				res := newGetEvaluationResponse(t, featureID, "2")
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, 20, nil)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushLatencyMetricsEvent(
@@ -474,7 +475,7 @@ func TestIntVariationDetails(t *testing.T) {
 		{
 			desc: "success: value is float",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
-				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, sdkVersion, user)
 				res := newGetEvaluationResponse(t, featureID, "2.2")
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, 20, nil)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushLatencyMetricsEvent(
@@ -533,7 +534,7 @@ func TestInt64Variation(t *testing.T) {
 			desc: "return default value when failed to get evaluation",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
 				err := api.NewErrStatus(http.StatusInternalServerError)
-				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, sdkVersion, user)
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(
 					nil,
 					100,
@@ -556,7 +557,7 @@ func TestInt64Variation(t *testing.T) {
 		{
 			desc: "return default value when faled to parse variation",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
-				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, sdkVersion, user)
 				res := newGetEvaluationResponse(t, featureID, "invalid")
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, 5, nil)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushLatencyMetricsEvent(
@@ -580,7 +581,7 @@ func TestInt64Variation(t *testing.T) {
 		{
 			desc: "success",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
-				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, sdkVersion, user)
 				res := newGetEvaluationResponse(t, featureID, "2")
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, 10, nil)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushLatencyMetricsEvent(
@@ -604,7 +605,7 @@ func TestInt64Variation(t *testing.T) {
 		{
 			desc: "success: value is float",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
-				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, sdkVersion, user)
 				res := newGetEvaluationResponse(t, featureID, "2.2")
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, 10, nil)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushLatencyMetricsEvent(
@@ -655,7 +656,7 @@ func TestInt64VariationDetails(t *testing.T) {
 			desc: "return default value when failed to get evaluation",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
 				err := api.NewErrStatus(http.StatusInternalServerError)
-				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, sdkVersion, user)
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(
 					nil,
 					100,
@@ -686,7 +687,7 @@ func TestInt64VariationDetails(t *testing.T) {
 		{
 			desc: "return default value when failed to parse variation",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
-				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, sdkVersion, user)
 				res := newGetEvaluationResponse(t, featureID, "invalid")
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, 5, nil)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushLatencyMetricsEvent(
@@ -718,7 +719,7 @@ func TestInt64VariationDetails(t *testing.T) {
 		{
 			desc: "success",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
-				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, sdkVersion, user)
 				res := newGetEvaluationResponse(t, featureID, "2")
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, 10, nil)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushLatencyMetricsEvent(
@@ -750,7 +751,7 @@ func TestInt64VariationDetails(t *testing.T) {
 		{
 			desc: "success: value is float",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
-				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, sdkVersion, user)
 				res := newGetEvaluationResponse(t, featureID, "2.2")
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, 10, nil)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushLatencyMetricsEvent(
@@ -809,7 +810,7 @@ func TestFloat64Variation(t *testing.T) {
 			desc: "return default value when failed to get evaluation",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
 				err := api.NewErrStatus(http.StatusInternalServerError)
-				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, sdkVersion, user)
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(
 					nil,
 					100, err,
@@ -831,7 +832,7 @@ func TestFloat64Variation(t *testing.T) {
 		{
 			desc: "return default value when faled to parse variation",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
-				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, sdkVersion, user)
 				res := newGetEvaluationResponse(t, featureID, "invalid")
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, 100, nil)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushLatencyMetricsEvent(
@@ -855,7 +856,7 @@ func TestFloat64Variation(t *testing.T) {
 		{
 			desc: "success",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
-				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, sdkVersion, user)
 				res := newGetEvaluationResponse(t, featureID, "2.2")
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, 100, nil)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushLatencyMetricsEvent(
@@ -906,7 +907,7 @@ func TestFloat64VariationDetails(t *testing.T) {
 			desc: "return default value when failed to get evaluation",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
 				err := api.NewErrStatus(http.StatusInternalServerError)
-				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, sdkVersion, user)
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(
 					nil,
 					100, err,
@@ -936,7 +937,7 @@ func TestFloat64VariationDetails(t *testing.T) {
 		{
 			desc: "return default value when failed to parse variation",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
-				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, sdkVersion, user)
 				res := newGetEvaluationResponse(t, featureID, "invalid")
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, 100, nil)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushLatencyMetricsEvent(
@@ -968,7 +969,7 @@ func TestFloat64VariationDetails(t *testing.T) {
 		{
 			desc: "success",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
-				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, sdkVersion, user)
 				res := newGetEvaluationResponse(t, featureID, "2.2")
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, 100, nil)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushLatencyMetricsEvent(
@@ -1027,7 +1028,7 @@ func TestStringVariation(t *testing.T) {
 			desc: "return default value when failed to get evaluation",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
 				err := api.NewErrStatus(http.StatusInternalServerError)
-				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, sdkVersion, user)
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(
 					nil,
 					100, err,
@@ -1049,7 +1050,7 @@ func TestStringVariation(t *testing.T) {
 		{
 			desc: "success",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
-				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, sdkVersion, user)
 				res := newGetEvaluationResponse(t, featureID, "value")
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, 100, nil)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushLatencyMetricsEvent(
@@ -1100,7 +1101,7 @@ func TestStringVariationDetails(t *testing.T) {
 			desc: "return default value when failed to get evaluation",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
 				err := api.NewErrStatus(http.StatusInternalServerError)
-				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, sdkVersion, user)
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(
 					nil,
 					100, err,
@@ -1130,7 +1131,7 @@ func TestStringVariationDetails(t *testing.T) {
 		{
 			desc: "success",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
-				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, sdkVersion, user)
 				res := newGetEvaluationResponse(t, featureID, "value")
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, 100, nil)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushLatencyMetricsEvent(
@@ -1193,7 +1194,7 @@ func TestJSONVariation(t *testing.T) {
 			desc: "failed to get evaluation",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
 				err := api.NewErrStatus(http.StatusInternalServerError)
-				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, sdkVersion, user)
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(
 					nil,
 					100, err,
@@ -1215,7 +1216,7 @@ func TestJSONVariation(t *testing.T) {
 		{
 			desc: "faled to unmarshal variation",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
-				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, sdkVersion, user)
 				res := newGetEvaluationResponse(t, featureID, `invalid`)
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, 100, nil)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushLatencyMetricsEvent(
@@ -1239,7 +1240,7 @@ func TestJSONVariation(t *testing.T) {
 		{
 			desc: "success",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
-				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, sdkVersion, user)
 				res := newGetEvaluationResponse(t, featureID, `{"str": "str2", "int": "int2"}`)
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, 100, nil)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushLatencyMetricsEvent(
@@ -1294,7 +1295,7 @@ func TestObjectVariation(t *testing.T) {
 			desc: "failed to get evaluation",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
 				err := api.NewErrStatus(http.StatusInternalServerError)
-				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, sdkVersion, user)
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(
 					nil,
 					100, err,
@@ -1322,7 +1323,7 @@ func TestObjectVariation(t *testing.T) {
 		{
 			desc: "failed to unmarshal variation",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
-				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, sdkVersion, user)
 				res := newGetEvaluationResponse(t, featureID, `invalid`)
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, 100, nil)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushLatencyMetricsEvent(
@@ -1352,7 +1353,7 @@ func TestObjectVariation(t *testing.T) {
 		{
 			desc: "success:map",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
-				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, sdkVersion, user)
 				res := newGetEvaluationResponse(t, featureID, `{"str": "str2", "int": "int2"}`)
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, 100, nil)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushLatencyMetricsEvent(
@@ -1376,7 +1377,7 @@ func TestObjectVariation(t *testing.T) {
 		{
 			desc: "success:bool",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
-				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, sdkVersion, user)
 				res := newGetEvaluationResponse(t, featureID, `true`)
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, 100, nil)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushLatencyMetricsEvent(
@@ -1400,7 +1401,7 @@ func TestObjectVariation(t *testing.T) {
 		{
 			desc: "success:array of string",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
-				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, sdkVersion, user)
 				res := newGetEvaluationResponse(t, featureID, `["str1", "str2"]`)
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, 100, nil)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushLatencyMetricsEvent(
@@ -1424,7 +1425,7 @@ func TestObjectVariation(t *testing.T) {
 		{
 			desc: "success:array of float",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
-				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, sdkVersion, user)
 				res := newGetEvaluationResponse(t, featureID, `{"str": "str2", "results": [1.1,2.22]}`)
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, 100, nil)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushLatencyMetricsEvent(
@@ -1448,7 +1449,7 @@ func TestObjectVariation(t *testing.T) {
 		{
 			desc: "success:array of object",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
-				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, sdkVersion, user)
 				res := newGetEvaluationResponse(t, featureID, `[{"str": "str1", "results": [1,2]}, {"str": "str2", "results": [3,4]}]`)
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, 100, nil)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushLatencyMetricsEvent(
@@ -1478,7 +1479,7 @@ func TestObjectVariation(t *testing.T) {
 		{
 			desc: "success: json",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
-				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, sdkVersion, user)
 				res := newGetEvaluationResponse(t, featureID, `{"str": "str1", "int": "int1"}`)
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, 100, nil)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushLatencyMetricsEvent(
@@ -1539,7 +1540,7 @@ func TestObjectVariationDetails(t *testing.T) {
 			desc: "failed to get evaluation",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
 				err := api.NewErrStatus(http.StatusInternalServerError)
-				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, sdkVersion, user)
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(
 					nil,
 					100, err,
@@ -1575,7 +1576,7 @@ func TestObjectVariationDetails(t *testing.T) {
 		{
 			desc: "failed to unmarshal variation",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
-				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, sdkVersion, user)
 				res := newGetEvaluationResponse(t, featureID, `invalid`)
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, 100, nil)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushLatencyMetricsEvent(
@@ -1613,7 +1614,7 @@ func TestObjectVariationDetails(t *testing.T) {
 		{
 			desc: "success:map",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
-				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, sdkVersion, user)
 				res := newGetEvaluationResponse(t, featureID, `{"str": "str2", "int": "int2"}`)
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, 100, nil)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushLatencyMetricsEvent(
@@ -1645,7 +1646,7 @@ func TestObjectVariationDetails(t *testing.T) {
 		{
 			desc: "success:bool",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
-				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, sdkVersion, user)
 				res := newGetEvaluationResponse(t, featureID, `true`)
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, 100, nil)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushLatencyMetricsEvent(
@@ -1677,7 +1678,7 @@ func TestObjectVariationDetails(t *testing.T) {
 		{
 			desc: "success:array of string",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
-				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, sdkVersion, user)
 				res := newGetEvaluationResponse(t, featureID, `["str1", "str2"]`)
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, 100, nil)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushLatencyMetricsEvent(
@@ -1709,7 +1710,7 @@ func TestObjectVariationDetails(t *testing.T) {
 		{
 			desc: "success:array of float",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
-				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, sdkVersion, user)
 				res := newGetEvaluationResponse(t, featureID, `{"str": "str2", "results": [1,2]}`)
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, 100, nil)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushLatencyMetricsEvent(
@@ -1743,7 +1744,7 @@ func TestObjectVariationDetails(t *testing.T) {
 		{
 			desc: "success:array of object",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
-				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, sdkVersion, user)
 				res := newGetEvaluationResponse(t, featureID, `[{"str": "str1", "results": [1,2]}, {"str": "str2", "results": [3,4]}]`)
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, 100, nil)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushLatencyMetricsEvent(
@@ -1781,7 +1782,7 @@ func TestObjectVariationDetails(t *testing.T) {
 		{
 			desc: "success: json",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
-				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, sdkVersion, user)
 				res := newGetEvaluationResponse(t, featureID, `{"str": "str1", "int": "int1"}`)
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, 100, nil)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushLatencyMetricsEvent(
@@ -1854,7 +1855,7 @@ func TestGetEvaluation(t *testing.T) {
 			desc: "get evaluations returns timeout error",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
 				err := api.NewErrStatus(http.StatusGatewayTimeout)
-				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, sdkVersion, user)
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(
 					nil,
 					100, err,
@@ -1873,7 +1874,7 @@ func TestGetEvaluation(t *testing.T) {
 			desc: "get evaluations returns internal error",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
 				err := api.NewErrStatus(http.StatusGatewayTimeout)
-				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, sdkVersion, user)
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(
 					nil,
 					100, err,
@@ -1891,7 +1892,7 @@ func TestGetEvaluation(t *testing.T) {
 		{
 			desc: "invalid get evaluation res: res is nil",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
-				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, sdkVersion, user)
 				var res *model.GetEvaluationResponse
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, 100, nil)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushLatencyMetricsEvent(
@@ -1915,7 +1916,7 @@ func TestGetEvaluation(t *testing.T) {
 		{
 			desc: "invalid get evaluation res: evaluation is nil",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
-				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, sdkVersion, user)
 				res := newGetEvaluationResponse(t, featureID, "value")
 				res.Evaluation = nil
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, 100, nil)
@@ -1940,7 +1941,7 @@ func TestGetEvaluation(t *testing.T) {
 		{
 			desc: "invalid get evaluation res: feature id doesn't match",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
-				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, sdkVersion, user)
 				res := newGetEvaluationResponse(t, "invalid-feature-id", "value")
 				err := fmt.Errorf(
 					errResponseDifferentFeatureIDs,
@@ -1969,7 +1970,7 @@ func TestGetEvaluation(t *testing.T) {
 		{
 			desc: "invalid get evaluation res: variation value is empty",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
-				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, sdkVersion, user)
 				res := newGetEvaluationResponse(t, featureID, "")
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, 100, nil)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushLatencyMetricsEvent(
@@ -1993,7 +1994,7 @@ func TestGetEvaluation(t *testing.T) {
 		{
 			desc: "success",
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
-				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, sdkVersion, user)
 				res := newGetEvaluationResponse(t, featureID, "value")
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(
 					res,
@@ -2228,7 +2229,7 @@ func TestGetEvaluationDetails(t *testing.T) {
 			user:      newUser(t, sdkUserID),
 			featureID: sdkFeatureID,
 			setup: func(ctx context.Context, s *sdk, user *user.User, featureID string) {
-				req := model.NewGetEvaluationRequest(sdkTag, featureID, user)
+				req := model.NewGetEvaluationRequest(sdkTag, featureID, sdkVersion, user)
 				res := newGetEvaluationResponse(t, featureID, "true")
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, 100, nil)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushLatencyMetricsEvent(
@@ -2312,6 +2313,7 @@ func newSDKWithMock(t *testing.T, mockCtrl *gomock.Controller) *sdk {
 	t.Helper()
 	return &sdk{
 		tag:            sdkTag,
+		version:        sdkVersion,
 		apiClient:      mockapi.NewMockClient(mockCtrl),
 		eventProcessor: mockevent.NewMockProcessor(mockCtrl),
 		loggers: log.NewLoggers(&log.LoggersConfig{

--- a/test/e2e/api_test.go
+++ b/test/e2e/api_test.go
@@ -18,7 +18,7 @@ func TestGetEvaluation(t *testing.T) {
 	t.Parallel()
 	client := newAPIClient(t, *apiKey)
 	user := user.NewUser(userID, nil)
-	res, _, err := client.GetEvaluation(model.NewGetEvaluationRequest(tag, featureID, user))
+	res, _, err := client.GetEvaluation(model.NewGetEvaluationRequest(tag, featureID, sdkVersion, user))
 	assert.NoError(t, err)
 	assert.Equal(t, featureID, res.Evaluation.FeatureID)
 	assert.Equal(t, featureIDVariation2, res.Evaluation.VariationValue)
@@ -31,7 +31,7 @@ func TestGetFeatureFlags(t *testing.T) {
 	// Get all the features by tag
 	featureFlagsID := ""
 	requestedAt := int64(1)
-	resp, _, err := client.GetFeatureFlags(model.NewGetFeatureFlagsRequest(tag, featureFlagsID, requestedAt))
+	resp, _, err := client.GetFeatureFlags(model.NewGetFeatureFlagsRequest(tag, featureFlagsID, sdkVersion, requestedAt))
 	assert.NoError(t, err)
 	assert.True(t, len(resp.Features) >= 1)
 	assert.True(t, resp.FeatureFlagsID != featureFlagsID)
@@ -53,7 +53,7 @@ func TestGetFeatureFlags(t *testing.T) {
 	featureFlagsID = resp.FeatureFlagsID
 	requestedAt, err = strconv.ParseInt(resp.RequestedAt, 10, 64)
 	assert.NoError(t, err)
-	resp, _, err = client.GetFeatureFlags(model.NewGetFeatureFlagsRequest(tag, featureFlagsID, requestedAt))
+	resp, _, err = client.GetFeatureFlags(model.NewGetFeatureFlagsRequest(tag, featureFlagsID, sdkVersion, requestedAt))
 	assert.NoError(t, err)
 	assert.Empty(t, resp.Features)
 	assert.True(t, resp.FeatureFlagsID == featureFlagsID)
@@ -141,7 +141,7 @@ func TestRegisterEvents(t *testing.T) {
 		Type: model.SizeMetricsEventType,
 	})
 	assert.NoError(t, err)
-	sizeMetricsEvent, err := json.Marshal(model.NewMetricsEvent(sizeMetrics))
+	sizeMetricsEvent, err := json.Marshal(model.NewMetricsEvent(sizeMetrics, sdkVersion))
 	assert.NoError(t, err)
 	internalError, err := json.Marshal(&model.InternalSDKErrorMetricsEvent{
 		APIID:  model.GetEvaluation,
@@ -149,7 +149,7 @@ func TestRegisterEvents(t *testing.T) {
 		Type:   model.InternalSDKErrorMetricsEventType,
 	})
 	assert.NoError(t, err)
-	iemetricsEvent, err := json.Marshal(model.NewMetricsEvent(internalError))
+	iemetricsEvent, err := json.Marshal(model.NewMetricsEvent(internalError, sdkVersion))
 	assert.NoError(t, err)
 	timeoutError, err := json.Marshal(&model.TimeoutErrorMetricsEvent{
 		APIID:  model.GetEvaluation,
@@ -157,7 +157,7 @@ func TestRegisterEvents(t *testing.T) {
 		Type:   model.TimeoutErrorMetricsEventType,
 	})
 	assert.NoError(t, err)
-	temetricsEvent, err := json.Marshal(model.NewMetricsEvent(timeoutError))
+	temetricsEvent, err := json.Marshal(model.NewMetricsEvent(timeoutError, sdkVersion))
 	assert.NoError(t, err)
 	latency, err := json.Marshal(&model.LatencyMetricsEvent{
 		APIID:         model.GetEvaluation,
@@ -166,15 +166,15 @@ func TestRegisterEvents(t *testing.T) {
 		Type:          model.LatencyMetricsEventType,
 	})
 	assert.NoError(t, err)
-	lmetricsEvent, err := json.Marshal(model.NewMetricsEvent(latency))
+	lmetricsEvent, err := json.Marshal(model.NewMetricsEvent(latency, sdkVersion))
 	assert.NoError(t, err)
 	badRequest, err := json.Marshal(model.NewBadRequestErrorMetricsEvent(tag, model.GetEvaluation))
 	assert.NoError(t, err)
-	brmetricsEvent, err := json.Marshal(model.NewMetricsEvent(badRequest))
+	brmetricsEvent, err := json.Marshal(model.NewMetricsEvent(badRequest, sdkVersion))
 	assert.NoError(t, err)
 	internalServerError, err := json.Marshal(model.NewInternalServerErrorMetricsEvent(tag, model.GetEvaluation))
 	assert.NoError(t, err)
-	iesmetricsEvent, err := json.Marshal(model.NewMetricsEvent(internalServerError))
+	iesmetricsEvent, err := json.Marshal(model.NewMetricsEvent(internalServerError, sdkVersion))
 	assert.NoError(t, err)
 	req := model.NewRegisterEventsRequest(
 		[]*model.Event{

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -9,6 +9,7 @@ const (
 	timeout = 20 * time.Second
 
 	tag                 = "go-server"
+	sdkVersion          = "1.0.0"
 	userID              = "bucketeer-go-server-user-id-1"
 	featureID           = "feature-go-server-e2e-string"
 	featureIDVariation1 = "value-1"


### PR DESCRIPTION
This PR introduces the ability to set the SDK version through options when creating a new SDK instance. 
This change is necessary for building an OpenFeature provider to set SDK version .
