### PR TITLE
chore: enhance SDK with versioning support in cache processors and requests

### DIFF
--- a/pkg/bucketeer/cache/processor/feature_flag_processor.go
+++ b/pkg/bucketeer/cache/processor/feature_flag_processor.go
@@ -66,6 +66,9 @@ type FeatureFlagProcessorConfig struct {
 	// Tag is the Feature Flag tag
 	// The tag is set when a Feature Flag is created, and can be retrieved from the admin console.
 	Tag string
+
+	// SDKVersion is the SDK version.
+	SDKVersion string
 }
 
 const (
@@ -84,6 +87,7 @@ func NewFeatureFlagProcessor(conf *FeatureFlagProcessorConfig) FeatureFlagProces
 		pushSizeMetricsEvent:    conf.PushSizeMetricsEvent,
 		pushErrorEvent:          conf.PushErrorEvent,
 		tag:                     conf.Tag,
+		sdkVersion:              conf.SDKVersion,
 		closeCh:                 make(chan struct{}),
 		loggers:                 conf.Loggers,
 	}

--- a/pkg/bucketeer/cache/processor/segment_user_processor.go
+++ b/pkg/bucketeer/cache/processor/segment_user_processor.go
@@ -35,6 +35,7 @@ type segmentUserProcessor struct {
 	pushSizeMetricsEvent    func(sizeByte int, api model.APIID)
 	pushErrorEvent          func(err error, api model.APIID)
 	tag                     string
+	sdkVersion              string
 	closeCh                 chan struct{}
 	loggers                 *log.Loggers
 }
@@ -67,6 +68,9 @@ type SegmentUserProcessorConfig struct {
 	//
 	// Note: this tag is used to report metric events.
 	Tag string
+
+	// SDKVersion is the SDK version.
+	SDKVersion string
 }
 
 const (
@@ -84,6 +88,7 @@ func NewSegmentUserProcessor(conf *SegmentUserProcessorConfig) SegmentUserProces
 		pushSizeMetricsEvent:    conf.PushSizeMetricsEvent,
 		pushErrorEvent:          conf.PushErrorEvent,
 		tag:                     conf.Tag,
+		sdkVersion:              conf.SDKVersion,
 		closeCh:                 make(chan struct{}),
 		loggers:                 conf.Loggers,
 	}
@@ -141,6 +146,7 @@ func (p *segmentUserProcessor) updateCache() error {
 	req := model.NewGetSegmentUsersRequest(
 		ftsID,
 		requestedAt,
+		p.sdkVersion,
 	)
 	// Get the latest cache from the server
 	reqStart := time.Now()

--- a/pkg/bucketeer/model/get_segment_users_request.go
+++ b/pkg/bucketeer/model/get_segment_users_request.go
@@ -1,9 +1,5 @@
 package model
 
-import (
-	"github.com/bucketeer-io/go-server-sdk/pkg/bucketeer/version"
-)
-
 type GetSegmentUsersRequest struct {
 	SegmentIDs  []string     `json:"segmentIds"`
 	RequestedAt int64        `json:"requestedAt"`
@@ -11,11 +7,15 @@ type GetSegmentUsersRequest struct {
 	SDKVersion  string       `json:"sdkVersion"`
 }
 
-func NewGetSegmentUsersRequest(segmentIDs []string, requestedAt int64) *GetSegmentUsersRequest {
+func NewGetSegmentUsersRequest(
+	segmentIDs []string,
+	requestedAt int64,
+	sdkVersion string,
+) *GetSegmentUsersRequest {
 	return &GetSegmentUsersRequest{
 		SegmentIDs:  segmentIDs,
 		RequestedAt: requestedAt,
 		SourceID:    SourceIDGoServer,
-		SDKVersion:  version.SDKVersion,
+		SDKVersion:  sdkVersion,
 	}
 }

--- a/pkg/bucketeer/model/get_segment_users_request_test.go
+++ b/pkg/bucketeer/model/get_segment_users_request_test.go
@@ -12,10 +12,11 @@ func TestNewGetSegmentUsersRequest(t *testing.T) {
 	t.Parallel()
 	segmentIDs := []string{"seg-1", "seg-2"}
 	requestedAt := int64(1)
-	e := NewGetSegmentUsersRequest(segmentIDs, requestedAt)
+	sdkVersion := version.SDKVersion
+	e := NewGetSegmentUsersRequest(segmentIDs, requestedAt, sdkVersion)
 	assert.IsType(t, &GetSegmentUsersRequest{}, e)
 	assert.Equal(t, segmentIDs, e.SegmentIDs)
 	assert.Equal(t, requestedAt, e.RequestedAt)
 	assert.Equal(t, SourceIDGoServer, e.SourceID)
-	assert.Equal(t, version.SDKVersion, e.SDKVersion)
+	assert.Equal(t, sdkVersion, e.SDKVersion)
 }

--- a/pkg/bucketeer/sdk.go
+++ b/pkg/bucketeer/sdk.go
@@ -193,6 +193,7 @@ func NewSDK(ctx context.Context, opts ...Option) (SDK, error) {
 		client,
 		processor,
 		dopts.tag,
+		dopts.sdkVersion,
 		loggers,
 	)
 	sucp := newSegmentUserCacheProcessor(
@@ -200,6 +201,8 @@ func NewSDK(ctx context.Context, opts ...Option) (SDK, error) {
 		dopts.cachePollingInterval,
 		client,
 		processor,
+		dopts.tag,
+		dopts.sdkVersion,
 		loggers,
 	)
 	// Run the cache processors to update the cache in background
@@ -226,6 +229,7 @@ func newFeatureFlagCacheProcessor(
 	apiClient api.Client,
 	eventProcessor event.Processor,
 	tag string,
+	sdkVersion string,
 	loggers *log.Loggers) cacheprocessor.FeatureFlagProcessor {
 	conf := &cacheprocessor.FeatureFlagProcessorConfig{
 		Cache:                   cache,
@@ -235,6 +239,7 @@ func newFeatureFlagCacheProcessor(
 		PushSizeMetricsEvent:    eventProcessor.PushSizeMetricsEvent,
 		PushErrorEvent:          eventProcessor.PushErrorEvent,
 		Tag:                     tag,
+		SDKVersion:              sdkVersion,
 		Loggers:                 loggers,
 	}
 	return cacheprocessor.NewFeatureFlagProcessor(conf)
@@ -245,6 +250,8 @@ func newSegmentUserCacheProcessor(
 	pollingInterval time.Duration,
 	apiClient api.Client,
 	eventProcessor event.Processor,
+	tag string,
+	sdkVersion string,
 	loggers *log.Loggers) cacheprocessor.SegmentUserProcessor {
 	conf := &cacheprocessor.SegmentUserProcessorConfig{
 		Cache:                   cache,
@@ -253,6 +260,8 @@ func newSegmentUserCacheProcessor(
 		PushLatencyMetricsEvent: eventProcessor.PushLatencyMetricsEvent,
 		PushSizeMetricsEvent:    eventProcessor.PushSizeMetricsEvent,
 		PushErrorEvent:          eventProcessor.PushErrorEvent,
+		Tag:                     tag,
+		SDKVersion:              sdkVersion,
 		Loggers:                 loggers,
 	}
 	return cacheprocessor.NewSegmentUserProcessor(conf)

--- a/test/e2e/api_test.go
+++ b/test/e2e/api_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bucketeer-io/go-server-sdk/pkg/bucketeer/model"
 	"github.com/bucketeer-io/go-server-sdk/pkg/bucketeer/user"
 	"github.com/bucketeer-io/go-server-sdk/pkg/bucketeer/uuid"
+	"github.com/bucketeer-io/go-server-sdk/pkg/bucketeer/version"
 )
 
 func TestGetEvaluation(t *testing.T) {
@@ -79,7 +80,7 @@ func TestGetSegmentUsers(t *testing.T) {
 
 	segmentIDs := []string{""}
 	requestedAt := int64(1)
-	resp, _, err := client.GetSegmentUsers(model.NewGetSegmentUsersRequest(segmentIDs, requestedAt))
+	resp, _, err := client.GetSegmentUsers(model.NewGetSegmentUsersRequest(segmentIDs, requestedAt, version.SDKVersion))
 	assert.NoError(t, err)
 	assert.True(t, len(resp.SegmentUsers) > 0)
 	assert.Empty(t, resp.DeletedSegmentIDs)
@@ -95,7 +96,7 @@ func TestGetSegmentUsers(t *testing.T) {
 	segmentIDs = []string{resp.SegmentUsers[0].SegmentID, randomID}
 	ra, err = strconv.ParseInt(resp.RequestedAt, 10, 64)
 	assert.NoError(t, err)
-	resp, _, err = client.GetSegmentUsers(model.NewGetSegmentUsersRequest(segmentIDs, ra))
+	resp, _, err = client.GetSegmentUsers(model.NewGetSegmentUsersRequest(segmentIDs, ra, version.SDKVersion))
 	assert.NoError(t, err)
 	assert.Empty(t, resp.SegmentUsers)
 	assert.NotEmpty(t, resp.DeletedSegmentIDs)

--- a/test/e2e/sdk_local_evaluation_test.go
+++ b/test/e2e/sdk_local_evaluation_test.go
@@ -283,6 +283,7 @@ func newLocalSDK(t *testing.T, ctx context.Context) bucketeer.SDK {
 		bucketeer.WithNumEventFlushWorkers(3),
 		bucketeer.WithEventFlushSize(1),
 		bucketeer.WithEnableDebugLog(true),
+		bucketeer.WithSDKVersion("1.5.5"),
 	)
 	assert.NoError(t, err)
 	return sdk

--- a/test/e2e/sdk_test.go
+++ b/test/e2e/sdk_test.go
@@ -602,6 +602,7 @@ func newSDK(t *testing.T, ctx context.Context) bucketeer.SDK {
 		bucketeer.WithNumEventFlushWorkers(3),
 		bucketeer.WithEventFlushSize(1),
 		bucketeer.WithEnableDebugLog(true),
+		bucketeer.WithSDKVersion("1.5.5"),
 	)
 	assert.NoError(t, err)
 	return sdk


### PR DESCRIPTION
This PR adds proper SDK version information to all API requests by fixing the FeatureFlagProcessor configuration. The issue was causing 400 Bad Request errors in e2e tests when using local evaluation mode.

- Added SDKVersion field to FeatureFlagProcessorConfig struct
- Updated NewFeatureFlagProcessor function to set the sdkVersion field from the config
- Modified newFeatureFlagCacheProcessor function in sdk.go to pass SDK version parameter
- Updated all relevant tests to include SDK version parameter in requests
