### PR TITLE
chore: rename WithSDKVersion to WithWrapperSDKVersion for internal use indication

### DIFF
--- a/pkg/bucketeer/option.go
+++ b/pkg/bucketeer/option.go
@@ -112,8 +112,12 @@ func WithPort(port int) Option {
 	}
 }
 
-// WithSDKVersion sets the SDK version. (Default: version.SDKVersion)
-func WithSDKVersion(sdkVersion string) Option {
+// WithWrapperSDKVersion sets the SDK version explicitly. (Default: version.SDKVersion)
+// IMPORTANT: This option is intended for internal use only.
+// It should NOT be set by developers directly integrating this SDK.
+// Use this option ONLY when another SDK acts as a proxy and wraps this native SDK.
+// In such cases, set this value to the version of the proxy SDK.
+func WithWrapperSDKVersion(sdkVersion string) Option {
 	return func(opts *options) {
 		opts.sdkVersion = sdkVersion
 	}

--- a/test/e2e/sdk_local_evaluation_test.go
+++ b/test/e2e/sdk_local_evaluation_test.go
@@ -283,7 +283,7 @@ func newLocalSDK(t *testing.T, ctx context.Context) bucketeer.SDK {
 		bucketeer.WithNumEventFlushWorkers(3),
 		bucketeer.WithEventFlushSize(1),
 		bucketeer.WithEnableDebugLog(true),
-		bucketeer.WithSDKVersion("1.5.5"),
+		bucketeer.WithWrapperSDKVersion("1.5.5"),
 	)
 	assert.NoError(t, err)
 	return sdk

--- a/test/e2e/sdk_test.go
+++ b/test/e2e/sdk_test.go
@@ -602,7 +602,7 @@ func newSDK(t *testing.T, ctx context.Context) bucketeer.SDK {
 		bucketeer.WithNumEventFlushWorkers(3),
 		bucketeer.WithEventFlushSize(1),
 		bucketeer.WithEnableDebugLog(true),
-		bucketeer.WithSDKVersion("1.5.5"),
+		bucketeer.WithWrapperSDKVersion("1.5.5"),
 	)
 	assert.NoError(t, err)
 	return sdk


### PR DESCRIPTION
Rename WithSDKVersion to WithWrapperSDKVersion.
ref: https://github.com/bucketeer-io/android-client-sdk/pull/226#discussion_r2081159539