### PR TITLE
chore: validate the source ID when initializing the SDK

### DIFF
--- a/pkg/bucketeer/model/source_id.go
+++ b/pkg/bucketeer/model/source_id.go
@@ -3,7 +3,8 @@ package model
 type SourceIDType int32
 
 const (
-	SourceIDGoServer SourceIDType = 5
+	SourceIDGoServer      SourceIDType = 5
+	SourceIDOpenFeatureGo SourceIDType = 103
 )
 
 func (s SourceIDType) Int32() int32 {

--- a/pkg/bucketeer/sdk.go
+++ b/pkg/bucketeer/sdk.go
@@ -150,6 +150,12 @@ func NewSDK(ctx context.Context, opts ...Option) (SDK, error) {
 	}
 	loggers := log.NewLoggers(loggerConf)
 
+	// validate sourceID
+	if dopts.sourceID != model.SourceIDGoServer.Int32() &&
+		dopts.sourceID != model.SourceIDOpenFeatureGo.Int32() {
+		return nil, fmt.Errorf("invalid sourceID: %d", dopts.sourceID)
+	}
+
 	// The `host` is deprecated and it will be removed soon.
 	apiEndpoint := dopts.apiEndpoint
 	if apiEndpoint == "" {

--- a/pkg/bucketeer/sdk_test.go
+++ b/pkg/bucketeer/sdk_test.go
@@ -2342,6 +2342,60 @@ func newUser(t *testing.T, id string) *user.User {
 	return &user.User{ID: id}
 }
 
+func TestNewSDK(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		desc    string
+		opts    []Option
+		wantErr error
+		isErr   bool
+	}{
+		{
+			desc:    "success",
+			opts:    []Option{WithAPIKey("api-key"), WithAPIEndpoint("api.example.com"), WithScheme("https"), WithWrapperSourceID(model.SourceIDGoServer.Int32())},
+			wantErr: nil,
+			isErr:   false,
+		},
+		{
+			desc:    "empty API key",
+			opts:    []Option{WithAPIKey(""), WithAPIEndpoint("api.example.com"), WithScheme("https")},
+			wantErr: api.ErrEmptyAPIKey,
+			isErr:   true,
+		},
+		{
+			desc:    "invalid scheme",
+			opts:    []Option{WithAPIKey("api-key"), WithAPIEndpoint("api.example.com"), WithScheme("invalid")},
+			wantErr: api.ErrInvalidScheme,
+			isErr:   true,
+		},
+		{
+			desc:    "empty API endpoint",
+			opts:    []Option{WithAPIKey("api-key"), WithAPIEndpoint(""), WithScheme("https")},
+			wantErr: api.ErrEmptyAPIEndpoint,
+			isErr:   true,
+		},
+		{
+			desc:    "invalid sourceID",
+			opts:    []Option{WithAPIKey("api-key"), WithAPIEndpoint("api.example.com"), WithScheme("https"), WithWrapperSourceID(123)},
+			wantErr: fmt.Errorf("invalid sourceID: 123"),
+			isErr:   true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			sdk, err := NewSDK(ctx, tt.opts...)
+			if tt.isErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, sdk)
+			}
+		})
+	}
+}
+
 func newGetEvaluationResponse(t *testing.T, featureID, value string) *model.GetEvaluationResponse {
 	t.Helper()
 	return &model.GetEvaluationResponse{


### PR DESCRIPTION
fix #172 

In android client, we validate sourceID when initializing the SDK,(https://github.com/bucketeer-io/android-client-sdk/pull/226/files#diff-f06479dd41914b6f1d48d448eef46da78e20d43a6a4c932b74b451b49dc9fc8eR150-R163), and we should apply it to go-server-sdk.
