### PR TITLE
chore: optimize http timeout and flush interval for server-side usage

### DIFF
--- a/pkg/bucketeer/api/client.go
+++ b/pkg/bucketeer/api/client.go
@@ -139,7 +139,7 @@ func NewClient(conf *ClientConfig) (Client, error) {
 		apiKey:      conf.APIKey,
 		apiEndpoint: conf.APIEndpoint,
 		httpClient: &http.Client{
-			Timeout:   60 * time.Second,
+			Timeout:   5 * time.Second,
 			Transport: transport,
 		},
 		retryConfig: retry.Config{


### PR DESCRIPTION
## Summary

Optimizes timeout and flush interval defaults for server-to-server communication.

## Changes

- HTTP timeout: 60s → 5s
- Default flush interval: 10s → 30s
- Added docs about retry behavior with custom intervals

**5s timeout:** Server-to-server requests are fast (RegisterEvents p95: 1-2s). With retry logic, fast failure is better than waiting 60s on stalled connections.

**30s flush interval:** Reduces API load 3× while maintaining proper retry coverage. Server-side SDKs run continuously (unlike browser SDKs where users close tabs), so 30s latency is acceptable for analytics.

**Interaction:** With 5s timeout + 30s flush (24s deadline), all 3 retry attempts fit: 5s + 1s + 5s + 2s + 5s = 18s ✅
Users can still configure shorter intervals if needed. Failed events are automatically re-queued.
