### PR TITLE
fix: prevent zero-delay retries when initial interval <= 0

### DIFF
--- a/pkg/bucketeer/api/client.go
+++ b/pkg/bucketeer/api/client.go
@@ -110,8 +110,8 @@ func NewClient(conf *ClientConfig) (Client, error) {
 		maxRetries = 3
 	}
 	initialInterval := conf.RetryInitialInterval
-	if initialInterval == 0 {
-		initialInterval = 1 * time.Second
+	if initialInterval <= 0 {
+		initialInterval = retry.DefaultInitialInterval
 	}
 	maxInterval := conf.RetryMaxInterval
 	if maxInterval == 0 {

--- a/pkg/bucketeer/option_test.go
+++ b/pkg/bucketeer/option_test.go
@@ -137,7 +137,7 @@ func TestWithRetryInitialInterval(t *testing.T) {
 			expected: 100 * time.Millisecond,
 		},
 		{
-			name:     "set to 0 disables initial wait",
+			name:     "set to 0 is stored by option (replaced with default by client)",
 			input:    0,
 			expected: 0,
 		},

--- a/pkg/bucketeer/option_test.go
+++ b/pkg/bucketeer/option_test.go
@@ -137,7 +137,7 @@ func TestWithRetryInitialInterval(t *testing.T) {
 			expected: 100 * time.Millisecond,
 		},
 		{
-			name:     "set to 0 is stored by option (replaced with default by client)",
+			name:     "set to 0",
 			input:    0,
 			expected: 0,
 		},

--- a/pkg/bucketeer/retry/retry.go
+++ b/pkg/bucketeer/retry/retry.go
@@ -11,6 +11,8 @@ import (
 	"time"
 )
 
+const DefaultInitialInterval = 1 * time.Second
+
 // Config holds retry configuration.
 type Config struct {
 	MaxRetries      int           // Maximum number of retry attempts
@@ -157,7 +159,7 @@ func Do(ctx context.Context, cfg Config, fn func() error) error {
 // calculateBackoff returns the next backoff interval with jitter.
 func calculateBackoff(attempt int, cfg Config) time.Duration {
 	if cfg.InitialInterval <= 0 {
-		return 0
+		cfg.InitialInterval = DefaultInitialInterval
 	}
 
 	// Exponential backoff: initialInterval * (multiplier ^ attempt)

--- a/pkg/bucketeer/retry/retry_test.go
+++ b/pkg/bucketeer/retry/retry_test.go
@@ -184,7 +184,7 @@ func TestCalculateBackoff(t *testing.T) {
 		}
 	})
 
-	t.Run("zero initial interval returns zero", func(t *testing.T) {
+	t.Run("zero initial interval falls back to default", func(t *testing.T) {
 		t.Parallel()
 		cfg := Config{
 			InitialInterval: 0,
@@ -193,7 +193,19 @@ func TestCalculateBackoff(t *testing.T) {
 		}
 
 		backoff := calculateBackoff(0, cfg)
-		assert.Equal(t, time.Duration(0), backoff)
+		assert.Greater(t, backoff, time.Duration(0))
+	})
+
+	t.Run("negative initial interval falls back to default", func(t *testing.T) {
+		t.Parallel()
+		cfg := Config{
+			InitialInterval: -1 * time.Second,
+			MaxInterval:     10 * time.Second,
+			Multiplier:      2.0,
+		}
+
+		backoff := calculateBackoff(0, cfg)
+		assert.Greater(t, backoff, time.Duration(0))
 	})
 
 	t.Run("default multiplier is 2.0 when not set", func(t *testing.T) {


### PR DESCRIPTION
`calculateBackoff` returned 0 immediately for any `InitialInterval <= 0`,
causing zero-delay retries when called directly. `NewClient` also only
replaced `== 0` with the default, leaving negative values unguarded.

- `calculateBackoff`: fall back to `DefaultInitialInterval` (1s) instead of returning 0
- `NewClient`: broaden guard from `== 0` to `<= 0` to cover negative values
- Export `retry.DefaultInitialInterval` to remove the duplicate `1 * time.Second` literal

Mirrors the same hardening applied to the [Node.js SDK](https://github.com/bucketeer-io/node-server-sdk/pull/198/changes#diff-c3095d5010e65c52737a98a5d618ea24049ebe90c8470752426081d70ed6e012R278)

```
Since the default is 1s in the Go SDK, we could reset the value to 1 if it is set < 1.
```
