### PR TITLE
ci: replace classic pat with github app token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,13 @@ jobs:
     name: Release Please
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        with:
+          client-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
       - uses: googleapis/release-please-action@f3969c04a4ec81d7a9aa4010d84ae6a7602f86a7 # v4.1.1
         with:
-          token: ${{ secrets.WORKFLOW_TOKEN }} # We need to set the PAT so the update changelog docs page workflow can be triggered
+          token: ${{ steps.app-token.outputs.token }} # App token so the tag/release created by release-please can trigger other workflows

--- a/.github/workflows/update-changelog-docs-page.yml
+++ b/.github/workflows/update-changelog-docs-page.yml
@@ -29,6 +29,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        with:
+          client-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+          owner: bucketeer-io
+          repositories: bucketeer-docs
+          permission-actions: write
       - name: Workflow Dispatch
         uses: benc-uk/workflow-dispatch@798e70c97009500150087d30d9f11c5444830385 # v1.2.2
         env:
@@ -42,7 +50,7 @@ jobs:
           FROM_REPOSITORY_URL: https://github.com/bucketeer-io/go-server-sdk
         with:
           repo: ${{ env.DOC_REPO }}
-          token: ${{ secrets.REPO_ACCESS_PAT }}
+          token: ${{ steps.app-token.outputs.token }}
           workflow: update-changelog.yaml
           ref: main
           inputs: '{"doc_filename": "${{ env.DOC_FILENAME }}", "doc_filepath": "${{ env.DOC_FILEPATH }}", "doc_title": "${{ env.DOC_TITLE }}", "doc_slug": "${{ env.DOC_SLUG }}", "changelog_url": "${{ env.CHANGELOG_URL }}", "from_repository_name": "${{ env.FROM_REPOSITORY_NAME }}", "from_repository_url": "${{ env.FROM_REPOSITORY_URL }}", "commit_url": "${{ needs.setup.outputs.COMMIT_URL }}", "release_tag": "${{ needs.setup.outputs.RELEASE_TAG }}"}'


### PR DESCRIPTION
Part of https://github.com/bucketeer-io/bucketeer/issues/2703

Replaces the classic PATs (WORKFLOW_TOKEN, REPO_ACCESS_PAT) with short-lived installation tokens minted from a GitHub App via actions/create-github-app-token, as part of removing classic PATs from CI. The app token still allows the tag/release created by release-please to trigger the publish workflows.